### PR TITLE
chore: baseline CI and docs

### DIFF
--- a/docs/upgrade/BASELINE.md
+++ b/docs/upgrade/BASELINE.md
@@ -1,0 +1,14 @@
+# Baseline CI + E2E (Upgrade Prerequisite)
+
+Run these commands from repo root on every upgrade PR:
+
+1. `pnpm install`
+2. `pnpm -r --if-present lint`
+3. `pnpm -r --if-present typecheck`
+4. `pnpm -r --if-present test`
+5. `pnpm -r --if-present build`
+6. `pnpm e2e`
+
+Notes:
+- E2E entrypoint is `pnpm e2e` (`./scripts/run-e2e.sh`), which starts compose services, runs Playwright, and tears down.
+- If Docker images must be rebuilt after dependency changes, run `pnpm e2e:rebuild`.

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "db:seed": "pnpm --filter @atlaspm/core-api db:seed"
   },
   "devDependencies": {
+    "@types/node": "^22.13.1",
     "eslint": "^9.20.1",
     "prettier": "^3.5.1",
     "typescript": "^5.7.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      '@types/node':
+        specifier: ^22.13.1
+        version: 22.19.11
       eslint:
         specifier: ^9.20.1
         version: 9.39.3(jiti@1.21.7)


### PR DESCRIPTION
## Scope Summary
- Added baseline upgrade verification doc at `docs/upgrade/BASELINE.md`.
- Fixed baseline workspace build break by adding root `@types/node` dev dependency.
- No architecture changes (core-api/web-ui/collab boundaries unchanged).
- No auth model changes (OIDC assumptions unchanged).

## What Did NOT Change
- No feature behavior changes.
- No test relaxations or assertion removals.
- No audit/outbox/collab logic changes.

## Verification Commands Run
- `pnpm install`
- `pnpm -r --if-present lint`
- `pnpm -r --if-present typecheck` (no-op in current workspaces)
- `pnpm -r --if-present test`
- `pnpm -r --if-present build`
- `pnpm e2e`

## Risks / Rollback Plan
- Risk: low (dev dependency and docs only).
- Rollback: revert this PR commit and restore previous `pnpm-lock.yaml`.

## Docs
- Baseline CI/E2E checklist: `docs/upgrade/BASELINE.md`
- Tailwind v4 diff note (for later phase): `docs/upgrade/TW4_DIFFS.md`
