### PR TITLE
feat(multi-home): add task_project_links model for P2-1 (#87)

### DIFF
--- a/apps/core-api/prisma/migrations/20250301000000_add_task_project_links/migration.sql
+++ b/apps/core-api/prisma/migrations/20250301000000_add_task_project_links/migration.sql
@@ -1,0 +1,50 @@
+-- Migration: Add TaskProjectLink table for multi-home support
+-- Issue: #87
+
+-- Create task_project_links table
+CREATE TABLE IF NOT EXISTS "task_project_links" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "task_id" UUID NOT NULL,
+    "project_id" UUID NOT NULL,
+    "is_primary" BOOLEAN NOT NULL DEFAULT false,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "deleted_at" TIMESTAMP(3),
+    
+    CONSTRAINT "task_project_links_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "task_project_links_task_id_project_id_key" UNIQUE ("task_id", "project_id"),
+    CONSTRAINT "task_project_links_task_id_fkey" FOREIGN KEY ("task_id") REFERENCES "Task"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "task_project_links_project_id_fkey" FOREIGN KEY ("project_id") REFERENCES "Project"("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- Create indexes
+CREATE INDEX IF NOT EXISTS "task_project_links_task_id_idx" ON "task_project_links"("task_id");
+CREATE INDEX IF NOT EXISTS "task_project_links_project_id_idx" ON "task_project_links"("project_id");
+CREATE INDEX IF NOT EXISTS "task_project_links_project_id_deleted_at_idx" ON "task_project_links"("project_id", "deleted_at");
+
+-- Migrate existing data: Create links from existing task.projectId
+INSERT INTO "task_project_links" ("id", "task_id", "project_id", "is_primary", "created_at", "updated_at")
+SELECT 
+    gen_random_uuid(),
+    "id" as "task_id",
+    "projectId" as "project_id",
+    true as "is_primary",  -- Mark as primary for backward compatibility
+    "createdAt" as "created_at",
+    CURRENT_TIMESTAMP as "updated_at"
+FROM "Task"
+WHERE "deletedAt" IS NULL;
+
+-- Add trigger to auto-update updated_at
+CREATE OR REPLACE FUNCTION update_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW."updated_at" = CURRENT_TIMESTAMP;
+    RETURN NEW;
+END;
+$$ language 'plpgsql';
+
+DROP TRIGGER IF EXISTS update_task_project_links_updated_at ON "task_project_links";
+CREATE TRIGGER update_task_project_links_updated_at
+    BEFORE UPDATE ON "task_project_links"
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();

--- a/apps/core-api/prisma/schema.prisma
+++ b/apps/core-api/prisma/schema.prisma
@@ -138,6 +138,7 @@ model Project {
   memberships ProjectMembership[]
   sections    Section[]
   tasks       Task[]
+  taskLinks   TaskProjectLink[]
   rules       Rule[]
   webhooks    Webhook[]
   portfolios  PortfolioProject[]
@@ -223,6 +224,7 @@ model Task {
 
   project Project @relation(fields: [projectId], references: [id], onDelete: Cascade)
   section Section @relation(fields: [sectionId], references: [id], onDelete: Restrict)
+  projectLinks TaskProjectLink[]
   comments TaskComment[]
   mentions TaskMention[]
   notifications InboxNotification[]
@@ -736,4 +738,24 @@ model FormAnswer {
 
   @@unique([submissionId, questionId])
   @@map("form_answers")
+}
+
+// Multi-home support: Task can belong to multiple projects
+model TaskProjectLink {
+  id          String   @id @default(uuid())
+  taskId      String   @map("task_id")
+  projectId   String   @map("project_id")
+  isPrimary   Boolean  @default(false) @map("is_primary") // Original project for backward compatibility
+  createdAt   DateTime @default(now()) @map("created_at")
+  updatedAt   DateTime @updatedAt @map("updated_at")
+  deletedAt   DateTime? @map("deleted_at")
+
+  task    Task    @relation(fields: [taskId], references: [id], onDelete: Cascade)
+  project Project @relation(fields: [projectId], references: [id], onDelete: Cascade)
+
+  @@unique([taskId, projectId])
+  @@index([taskId])
+  @@index([projectId])
+  @@index([projectId, deletedAt])
+  @@map("task_project_links")
 }

--- a/apps/core-api/src/app.module.ts
+++ b/apps/core-api/src/app.module.ts
@@ -32,10 +32,11 @@ import { RecurringTaskWorker } from './recurring-tasks/recurring-task.worker';
 import { FormsController } from './forms/forms.controller';
 import { TaskApprovalController } from './task-approvals/task-approval.controller';
 import { TaskTimeTrackingController } from './task-time-tracking/task-time-tracking.controller';
+import { TaskProjectLinksModule } from './task-project-links/task-project-links.module';
 import { ProjectRoleGuard, WorkspaceRoleGuard } from './auth/role.guard';
 
 @Module({
-  imports: [ConfigModule.forRoot({ isGlobal: true }), AuthModule, SearchModule, PortfoliosModule, WorkloadModule, DashboardsModule, IntegrationsModule],
+  imports: [ConfigModule.forRoot({ isGlobal: true }), AuthModule, SearchModule, PortfoliosModule, WorkloadModule, DashboardsModule, IntegrationsModule, TaskProjectLinksModule],
   controllers: [
     WorkspacesController,
     ProjectsController,

--- a/apps/core-api/src/task-project-links/task-project-link.controller.ts
+++ b/apps/core-api/src/task-project-links/task-project-link.controller.ts
@@ -1,0 +1,67 @@
+import { Controller, Post, Delete, Get, Body, Param, Query, UseGuards, ParseUUIDPipe } from '@nestjs/common';
+import { TaskProjectLinkService } from './task-project-link.service';
+import { AuthGuard } from '../auth/auth.guard';
+import { CurrentUser } from '../auth/current-user.decorator';
+import { RequireProjectAccess } from '../auth/project-access.decorator';
+
+class AddTaskToProjectDto {
+  taskId: string;
+  projectId: string;
+}
+
+class RemoveTaskFromProjectDto {
+  taskId: string;
+  projectId: string;
+}
+
+@Controller('task-project-links')
+@UseGuards(AuthGuard)
+export class TaskProjectLinkController {
+  constructor(private readonly linkService: TaskProjectLinkService) {}
+
+  @Post()
+  @RequireProjectAccess('projectId', 'ADMIN')
+  async addTaskToProject(
+    @Body() dto: AddTaskToProjectDto,
+    @CurrentUser() user: { userId: string },
+  ) {
+    return this.linkService.addTaskToProject(dto.taskId, dto.projectId, user.userId);
+  }
+
+  @Delete()
+  @RequireProjectAccess('projectId', 'ADMIN')
+  async removeTaskFromProject(
+    @Body() dto: RemoveTaskFromProjectDto,
+    @CurrentUser() user: { userId: string },
+  ) {
+    return this.linkService.removeTaskFromProject(dto.taskId, dto.projectId, user.userId);
+  }
+
+  @Get('task/:taskId/projects')
+  async getProjectsForTask(
+    @Param('taskId', ParseUUIDPipe) taskId: string,
+  ) {
+    return this.linkService.getProjectsForTask(taskId);
+  }
+
+  @Get('project/:projectId/tasks')
+  @RequireProjectAccess('projectId', 'VIEWER')
+  async getTasksForProject(
+    @Param('projectId', ParseUUIDPipe) projectId: string,
+    @Query('includeDeleted') includeDeleted?: string,
+  ) {
+    return this.linkService.getTasksForProject(
+      projectId,
+      includeDeleted === 'true',
+    );
+  }
+
+  @Post('task/:taskId/set-primary-project')
+  async setPrimaryProject(
+    @Param('taskId', ParseUUIDPipe) taskId: string,
+    @Body('projectId', ParseUUIDPipe) projectId: string,
+    @CurrentUser() user: { userId: string },
+  ) {
+    return this.linkService.setPrimaryProject(taskId, projectId, user.userId);
+  }
+}

--- a/apps/core-api/src/task-project-links/task-project-link.service.ts
+++ b/apps/core-api/src/task-project-links/task-project-link.service.ts
@@ -1,0 +1,282 @@
+import { Injectable, NotFoundException, ConflictException, ForbiddenException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { AuditService } from '../audit/audit.service';
+
+@Injectable()
+export class TaskProjectLinkService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly audit: AuditService,
+  ) {}
+
+  async addTaskToProject(taskId: string, projectId: string, userId: string) {
+    // Check if task exists
+    const task = await this.prisma.task.findUnique({
+      where: { id: taskId },
+    });
+    if (!task) {
+      throw new NotFoundException(`Task ${taskId} not found`);
+    }
+
+    // Check if project exists
+    const project = await this.prisma.project.findUnique({
+      where: { id: projectId },
+    });
+    if (!project) {
+      throw new NotFoundException(`Project ${projectId} not found`);
+    }
+
+    // Check if link already exists
+    const existingLink = await this.prisma.taskProjectLink.findUnique({
+      where: {
+        taskId_projectId: {
+          taskId,
+          projectId,
+        },
+      },
+    });
+
+    if (existingLink) {
+      if (existingLink.deletedAt) {
+        // Restore soft-deleted link
+        const link = await this.prisma.taskProjectLink.update({
+          where: { id: existingLink.id },
+          data: {
+            deletedAt: null,
+          },
+        });
+
+        await this.audit.log({
+          action: 'TASK_PROJECT_LINK_RESTORED',
+          actor: userId,
+          entityType: 'TaskProjectLink',
+          entityId: link.id,
+          afterJson: { taskId, projectId },
+        });
+
+        return link;
+      }
+      throw new ConflictException('Task is already linked to this project');
+    }
+
+    // Check if this is the first link (make it primary)
+    const existingLinks = await this.prisma.taskProjectLink.count({
+      where: {
+        taskId,
+        deletedAt: null,
+      },
+    });
+
+    const link = await this.prisma.taskProjectLink.create({
+      data: {
+        taskId,
+        projectId,
+        isPrimary: existingLinks === 0, // First link becomes primary
+      },
+    });
+
+    await this.audit.log({
+      action: 'TASK_PROJECT_LINK_CREATED',
+      actor: userId,
+      entityType: 'TaskProjectLink',
+      entityId: link.id,
+      afterJson: { taskId, projectId, isPrimary: existingLinks === 0 },
+    });
+
+    return link;
+  }
+
+  async removeTaskFromProject(taskId: string, projectId: string, userId: string) {
+    const link = await this.prisma.taskProjectLink.findUnique({
+      where: {
+        taskId_projectId: {
+          taskId,
+          projectId,
+        },
+      },
+    });
+
+    if (!link || link.deletedAt) {
+      throw new NotFoundException('Task project link not found');
+    }
+
+    // Check if this is the primary project and there are other links
+    if (link.isPrimary) {
+      const otherLinks = await this.prisma.taskProjectLink.count({
+        where: {
+          taskId,
+          deletedAt: null,
+          id: { not: link.id },
+        },
+      });
+
+      if (otherLinks > 0) {
+        throw new ForbiddenException(
+          'Cannot remove primary project. Set another project as primary first.',
+        );
+      }
+    }
+
+    // Soft delete
+    const updatedLink = await this.prisma.taskProjectLink.update({
+      where: { id: link.id },
+      data: {
+        deletedAt: new Date(),
+      },
+    });
+
+    await this.audit.log({
+      action: 'TASK_PROJECT_LINK_DELETED',
+      actor: userId,
+      entityType: 'TaskProjectLink',
+      entityId: link.id,
+      beforeJson: { taskId, projectId },
+    });
+
+    return updatedLink;
+  }
+
+  async getProjectsForTask(taskId: string) {
+    const links = await this.prisma.taskProjectLink.findMany({
+      where: {
+        taskId,
+        deletedAt: null,
+      },
+      include: {
+        project: {
+          select: {
+            id: true,
+            name: true,
+            workspaceId: true,
+          },
+        },
+      },
+      orderBy: {
+        isPrimary: 'desc',
+      },
+    });
+
+    return links;
+  }
+
+  async getTasksForProject(projectId: string, includeDeleted = false) {
+    const whereClause: any = {
+      projectId,
+    };
+
+    if (!includeDeleted) {
+      whereClause.deletedAt = null;
+    }
+
+    const links = await this.prisma.taskProjectLink.findMany({
+      where: whereClause,
+      include: {
+        task: {
+          select: {
+            id: true,
+            title: true,
+            status: true,
+            priority: true,
+            assigneeUserId: true,
+            dueAt: true,
+            completedAt: true,
+          },
+        },
+      },
+    });
+
+    return links;
+  }
+
+  async setPrimaryProject(taskId: string, projectId: string, userId: string) {
+    // Check if link exists
+    const link = await this.prisma.taskProjectLink.findUnique({
+      where: {
+        taskId_projectId: {
+          taskId,
+          projectId,
+        },
+      },
+    });
+
+    if (!link || link.deletedAt) {
+      throw new NotFoundException('Task project link not found');
+    }
+
+    // Use transaction to update primary status
+    await this.prisma.$transaction([
+      // Unset all primary flags for this task
+      this.prisma.taskProjectLink.updateMany({
+        where: {
+          taskId,
+          deletedAt: null,
+        },
+        data: {
+          isPrimary: false,
+        },
+      }),
+      // Set the new primary
+      this.prisma.taskProjectLink.update({
+        where: { id: link.id },
+        data: {
+          isPrimary: true,
+        },
+      }),
+    ]);
+
+    await this.audit.log({
+      action: 'TASK_PRIMARY_PROJECT_CHANGED',
+      actor: userId,
+      entityType: 'Task',
+      entityId: taskId,
+      afterJson: { primaryProjectId: projectId },
+    });
+
+    return this.prisma.taskProjectLink.findUnique({
+      where: { id: link.id },
+    });
+  }
+
+  // Migration helper: Create initial links for existing tasks
+  async migrateExistingTasks() {
+    const tasks = await this.prisma.task.findMany({
+      where: {
+        deletedAt: null,
+      },
+      select: {
+        id: true,
+        projectId: true,
+        createdAt: true,
+      },
+    });
+
+    const createdLinks = [];
+    for (const task of tasks) {
+      const existingLink = await this.prisma.taskProjectLink.findUnique({
+        where: {
+          taskId_projectId: {
+            taskId: task.id,
+            projectId: task.projectId,
+          },
+        },
+      });
+
+      if (!existingLink) {
+        const link = await this.prisma.taskProjectLink.create({
+          data: {
+            taskId: task.id,
+            projectId: task.projectId,
+            isPrimary: true,
+            createdAt: task.createdAt,
+          },
+        });
+        createdLinks.push(link);
+      }
+    }
+
+    return {
+      totalTasks: tasks.length,
+      createdLinks: createdLinks.length,
+    };
+  }
+}

--- a/apps/core-api/src/task-project-links/task-project-links.module.ts
+++ b/apps/core-api/src/task-project-links/task-project-links.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TaskProjectLinkController } from './task-project-link.controller';
+import { TaskProjectLinkService } from './task-project-link.service';
+import { AuditModule } from '../audit/audit.module';
+
+@Module({
+  imports: [AuditModule],
+  controllers: [TaskProjectLinkController],
+  providers: [TaskProjectLinkService],
+  exports: [TaskProjectLinkService],
+})
+export class TaskProjectLinksModule {}


### PR DESCRIPTION
## Summary

This PR implements the multi-home feature (P2-1) allowing tasks to belong to multiple projects.

## Changes

### Database Schema
- Add TaskProjectLink model for many-to-many relationship
- Add migration SQL with data migration for existing tasks
- Support soft delete for safe unlinking
- Add isPrimary flag for backward compatibility

### API Endpoints
- POST /task-project-links - Link task to project
- DELETE /task-project-links - Unlink task from project (soft delete)
- GET /task-project-links/task/:taskId/projects - List task projects
- GET /task-project-links/project/:projectId/tasks - List project tasks
- POST /task-project-links/task/:taskId/set-primary-project - Set primary project

### Features
- Backward compatible with existing task.projectId
- Audit logging for all operations
- Validation: Cannot remove primary project if other links exist
- Restore soft-deleted links when re-adding

## Migration

Existing tasks are automatically migrated to have a TaskProjectLink record with isPrimary=true.

## DoD Checklist

- [x] Database schema updated
- [x] Migration with data migration
- [x] API endpoints created
- [x] Audit logging added
- [x] Backward compatibility maintained

Closes #87