### PR TITLE
feat: issue #134 reschedule api with optimistic locking

### DIFF
--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -2324,3 +2324,26 @@
   - `pnpm --filter @atlaspm/web-ui build`
 - Risks/known gaps:
   - This smoke focuses on single-project deterministic setup; multi-user conflict paths are covered in Phase P3 issues.
+
+## 2026-03-04 - Issue #134: Reschedule API with optimistic locking
+- What changed:
+  - Added dedicated reschedule endpoint in core API:
+    - `apps/core-api/src/tasks/tasks.controller.ts`
+      - new `PATCH /tasks/:id/reschedule` with required `version`.
+      - validates input (`startAt`/`dueAt` at least one required + date range validation).
+      - returns structured `409` payload with latest server truth on version mismatch.
+      - appends audit/outbox (`task.rescheduled`) with before/after date payloads.
+  - Switched calendar drag-drop date updates to the dedicated reschedule API:
+    - `apps/web-ui/src/components/project-alt-views.tsx`
+      - retries on `409` using returned `latest.version` (fallback to task fetch when needed).
+  - Added integration coverage:
+    - `apps/core-api/test/core.integration.test.ts`
+      - success path verifies optimistic lock increment + audit/outbox emission.
+      - conflict path verifies `409` includes latest version/date truth.
+- Why:
+  - Issue #134 requires a safe scheduling write path with explicit optimistic locking and deterministic conflict handling before timeline/gantt drag editing.
+- How tested (exact commands):
+  - `pnpm --filter @atlaspm/core-api test -- test/core.integration.test.ts`
+  - `pnpm --filter @atlaspm/web-ui build`
+- Risks/known gaps:
+  - List/detail date edits still use general `PATCH /tasks/:id` in this wave; drag-based schedule updates now use dedicated reschedule endpoint.

--- a/apps/core-api/src/tasks/tasks.controller.ts
+++ b/apps/core-api/src/tasks/tasks.controller.ts
@@ -1,5 +1,6 @@
 import {
   Body,
+  BadRequestException,
   Controller,
   Delete,
   ForbiddenException,
@@ -216,6 +217,19 @@ class PatchTaskDto {
   @IsOptional()
   @IsInt()
   version?: number;
+}
+
+class RescheduleTaskDto {
+  @IsOptional()
+  @IsISO8601()
+  startAt?: string | null;
+
+  @IsOptional()
+  @IsISO8601()
+  dueAt?: string | null;
+
+  @IsInt()
+  version!: number;
 }
 
 class CompleteTaskDto {
@@ -691,6 +705,70 @@ export class TasksController {
         });
       }
 
+      return updated;
+    }).then((updated) => {
+      void this.indexTaskWithCustomFields(updated);
+      return updated;
+    });
+  }
+
+  @Patch('tasks/:id/reschedule')
+  async reschedule(@Param('id') id: string, @Body() body: RescheduleTaskDto, @CurrentRequest() req: AppRequest) {
+    const task = await this.prisma.task.findFirstOrThrow({ where: { id, deletedAt: null } });
+    await this.domain.requireProjectRole(task.projectId, req.user.sub, ProjectRole.MEMBER);
+    if (body.startAt === undefined && body.dueAt === undefined) {
+      throw new BadRequestException('Either startAt or dueAt must be provided');
+    }
+    if (body.version !== task.version) {
+      throw new ConflictException({
+        message: 'Version conflict',
+        latest: {
+          version: task.version,
+          startAt: task.startAt,
+          dueAt: task.dueAt,
+        },
+      });
+    }
+
+    const effectiveStartAt = body.startAt === undefined ? task.startAt?.toISOString() : body.startAt;
+    const effectiveDueAt = body.dueAt === undefined ? task.dueAt?.toISOString() : body.dueAt;
+    assertValidDateRange(effectiveStartAt, effectiveDueAt);
+
+    return this.prisma.$transaction(async (tx) => {
+      const updated = await tx.task.update({
+        where: { id },
+        data: {
+          startAt: body.startAt ? new Date(body.startAt) : body.startAt === null ? null : undefined,
+          dueAt: body.dueAt ? new Date(body.dueAt) : body.dueAt === null ? null : undefined,
+          version: { increment: 1 },
+        },
+      });
+      await this.domain.appendAuditOutbox({
+        tx,
+        actor: req.user.sub,
+        entityType: 'Task',
+        entityId: id,
+        action: 'task.rescheduled',
+        beforeJson: {
+          version: task.version,
+          startAt: task.startAt,
+          dueAt: task.dueAt,
+        },
+        afterJson: {
+          version: updated.version,
+          startAt: updated.startAt,
+          dueAt: updated.dueAt,
+        },
+        correlationId: req.correlationId,
+        outboxType: 'task.rescheduled',
+        payload: {
+          taskId: id,
+          projectId: task.projectId,
+          version: updated.version,
+          startAt: updated.startAt,
+          dueAt: updated.dueAt,
+        },
+      });
       return updated;
     }).then((updated) => {
       void this.indexTaskWithCustomFields(updated);

--- a/apps/core-api/test/core.integration.test.ts
+++ b/apps/core-api/test/core.integration.test.ts
@@ -2189,6 +2189,110 @@ describe('Core API Integration', () => {
     });
   });
 
+  test('PATCH /tasks/:id/reschedule updates dates with optimistic locking and emits audit/outbox', async () => {
+    const wsRes = await request(app.getHttpServer()).get('/workspaces').set('Authorization', `Bearer ${token}`).expect(200);
+    const workspaceId = wsRes.body[0].id;
+
+    const projectRes = await request(app.getHttpServer())
+      .post('/projects')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ workspaceId, name: `Reschedule Test ${Date.now()}` })
+      .expect(201);
+    const projectId = projectRes.body.id as string;
+
+    const startDate = new Date();
+    startDate.setDate(startDate.getDate() + 2);
+    const dueDate = new Date();
+    dueDate.setDate(dueDate.getDate() + 5);
+    const taskRes = await request(app.getHttpServer())
+      .post(`/projects/${projectId}/tasks`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        title: 'Task to reschedule',
+        startAt: startDate.toISOString(),
+        dueAt: dueDate.toISOString(),
+      })
+      .expect(201);
+
+    const taskId = taskRes.body.id as string;
+    const newDueDate = new Date();
+    newDueDate.setDate(newDueDate.getDate() + 10);
+    const rescheduleStart = new Date();
+    const rescheduleRes = await request(app.getHttpServer())
+      .patch(`/tasks/${taskId}/reschedule`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        dueAt: newDueDate.toISOString(),
+        version: taskRes.body.version,
+      })
+      .expect(200);
+
+    expect(rescheduleRes.body.id).toBe(taskId);
+    expect(rescheduleRes.body.version).toBe(taskRes.body.version + 1);
+    expect(String(rescheduleRes.body.dueAt).slice(0, 10)).toBe(newDueDate.toISOString().slice(0, 10));
+
+    const rescheduleAudit = await prisma.auditEvent.findFirst({
+      where: {
+        entityType: 'Task',
+        entityId: taskId,
+        action: 'task.rescheduled',
+        createdAt: { gte: rescheduleStart },
+      },
+      orderBy: { createdAt: 'desc' },
+    });
+    expect(rescheduleAudit).toBeTruthy();
+    expect((rescheduleAudit?.beforeJson as any)?.dueAt).toBeTruthy();
+    expect((rescheduleAudit?.afterJson as any)?.dueAt).toBeTruthy();
+
+    const rescheduleOutboxEvents = await prisma.outboxEvent.findMany({
+      where: { type: 'task.rescheduled', createdAt: { gte: rescheduleStart } },
+      orderBy: { createdAt: 'desc' },
+      take: 20,
+    });
+    const rescheduleOutbox = rescheduleOutboxEvents.find((event) => (event.payload as any)?.taskId === taskId);
+    expect(rescheduleOutbox).toBeTruthy();
+    expect((rescheduleOutbox?.payload as any)?.projectId).toBe(projectId);
+    expect((rescheduleOutbox?.payload as any)?.dueAt).toBeTruthy();
+  });
+
+  test('PATCH /tasks/:id/reschedule returns 409 with latest server truth on version conflict', async () => {
+    const wsRes = await request(app.getHttpServer()).get('/workspaces').set('Authorization', `Bearer ${token}`).expect(200);
+    const workspaceId = wsRes.body[0].id;
+
+    const projectRes = await request(app.getHttpServer())
+      .post('/projects')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ workspaceId, name: `Reschedule Conflict ${Date.now()}` })
+      .expect(201);
+    const projectId = projectRes.body.id as string;
+
+    const taskRes = await request(app.getHttpServer())
+      .post(`/projects/${projectId}/tasks`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ title: 'Task with conflict' })
+      .expect(201);
+    const taskId = taskRes.body.id as string;
+
+    const staleVersion = taskRes.body.version - 1;
+    const conflictRes = await request(app.getHttpServer())
+      .patch(`/tasks/${taskId}/reschedule`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        startAt: new Date().toISOString(),
+        version: staleVersion,
+      })
+      .expect(409);
+
+    expect(conflictRes.body).toMatchObject({
+      message: 'Version conflict',
+      latest: {
+        version: taskRes.body.version,
+      },
+    });
+    expect(conflictRes.body.latest).toHaveProperty('startAt');
+    expect(conflictRes.body.latest).toHaveProperty('dueAt');
+  });
+
   test('POST /tasks/:id/subtasks rejects invalid date range', async () => {
     const wsRes = await request(app.getHttpServer()).get('/workspaces').set('Authorization', `Bearer ${token}`).expect(200);
     const workspaceId = wsRes.body[0].id;

--- a/apps/web-ui/src/components/project-alt-views.tsx
+++ b/apps/web-ui/src/components/project-alt-views.tsx
@@ -45,6 +45,20 @@ function isApiConflictError(error: unknown): boolean {
   return /^API 409:/.test(error.message);
 }
 
+function extractConflictLatestVersion(error: unknown): number | null {
+  if (!(error instanceof Error)) return null;
+  const prefix = 'API 409:';
+  if (!error.message.startsWith(prefix)) return null;
+  const rawBody = error.message.slice(prefix.length).trim();
+  if (!rawBody) return null;
+  try {
+    const parsed = JSON.parse(rawBody) as { latest?: { version?: unknown } };
+    return typeof parsed.latest?.version === 'number' ? parsed.latest.version : null;
+  } catch {
+    return null;
+  }
+}
+
 function moveTaskPreview(
   groups: SectionTaskGroup[],
   taskId: string,
@@ -338,16 +352,18 @@ export function ProjectCalendarView({
       version: number;
     }) => {
       try {
-        return (await api(`/tasks/${taskId}`, {
+        return (await api(`/tasks/${taskId}/reschedule`, {
           method: 'PATCH',
           body: { [field]: value, version },
         })) as Task;
       } catch (error) {
         if (!isApiConflictError(error)) throw error;
-        const latestTask = (await api(`/tasks/${taskId}`)) as Task;
-        return (await api(`/tasks/${taskId}`, {
+        const latestVersion = extractConflictLatestVersion(error);
+        const fallbackVersion =
+          latestVersion ?? ((await api(`/tasks/${taskId}`)) as Task).version;
+        return (await api(`/tasks/${taskId}/reschedule`, {
           method: 'PATCH',
-          body: { [field]: value, version: latestTask.version },
+          body: { [field]: value, version: fallbackVersion },
         })) as Task;
       }
     },


### PR DESCRIPTION
## Summary
- implement Issue #134 (Execution order 13)
- add dedicated `PATCH /tasks/:id/reschedule` endpoint with required `version`
- return structured `409` latest payload on conflicts
- append audit/outbox (`task.rescheduled`) with before/after date values
- migrate calendar date drag updates to reschedule API

## Scope
- `apps/core-api/src/tasks/tasks.controller.ts`
- `apps/core-api/test/core.integration.test.ts`
- `apps/web-ui/src/components/project-alt-views.tsx`
- `WORKLOG.md`

## Verification
- `pnpm --filter @atlaspm/core-api test -- test/core.integration.test.ts`
- `pnpm --filter @atlaspm/web-ui build`
