### PR TITLE
docs(security): clarify dev-auth risk for DEV_AUTH_ENABLED

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ docker compose up -d --build
 
 - OIDC JWT verification via JWKS by default.
 - Dev auth mode is disabled by default and only enabled via `DEV_AUTH_ENABLED=true`.
+- Risk note: when `DEV_AUTH_ENABLED=true`, `POST /dev-auth/token` is intentionally available for local testing and can mint tokens for arbitrary `sub` values.
+- `DEV_AUTH_ENABLED=true` must be treated as a critical risk outside isolated local environments.
 - Dev auth token lifetime is configurable via `DEV_AUTH_TOKEN_TTL` (default `8h`).
 - Workspace/project admin operations are authorization-enforced server-side.
 - Collaboration JWT/service secrets:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,6 +9,8 @@
 - Production mode: OIDC JWT verification using issuer/audience and JWKS.
 - Stable user id is JWT `sub`.
 - Dev auth mode (`DEV_AUTH_ENABLED=true`) allows short-lived local test JWTs only.
+- Risk is conditional: when `DEV_AUTH_ENABLED=true`, `POST /dev-auth/token` can mint tokens for arbitrary identities and must not be exposed beyond trusted local use.
+- Production guardrail: enforce `DEV_AUTH_ENABLED=false` in deployed environments.
 
 ## Audit + Outbox
 - Every write appends:

--- a/docs/startup-ubuntu.md
+++ b/docs/startup-ubuntu.md
@@ -63,6 +63,7 @@ For local dev login, set:
 
 - `apps/core-api/.env` -> `DEV_AUTH_ENABLED=true`
 - `apps/web-ui/.env.local` -> `NEXT_PUBLIC_DEV_AUTH_ENABLED=true`
+- This setting is for isolated local development only. Do not enable it in shared or internet-reachable environments.
 
 ## 6) Start local stack
 


### PR DESCRIPTION
## Summary\n- Clarify that dev-auth risk is conditional on \.\n- Document that \ is local-only and must not be exposed in shared/public environments.\n\n## Files\n- README.md\n- docs/architecture.md\n- docs/startup-ubuntu.md\n\n## Verification\n- pnpm -r --if-present lint\n- pnpm -r --if-present type-check\n\n## Risk\n- Docs-only change, no runtime logic change.\n\n## Rollback\n- Revert commit \