### PR TITLE
feat: issue #175 timeline/gantt foundation split

### DIFF
--- a/apps/web-ui/src/app/projects/[id]/page.tsx
+++ b/apps/web-ui/src/app/projects/[id]/page.tsx
@@ -11,6 +11,7 @@ import { api } from '@/lib/api';
 import { queryKeys } from '@/lib/query-keys';
 import type { Project, ProjectMember, Section, SectionTaskGroup, Task } from '@/lib/types';
 import { parseCustomFieldFilters } from '@/lib/project-filters';
+import { resolveProjectView } from '@/lib/project-views';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { useI18n } from '@/lib/i18n';
@@ -52,15 +53,7 @@ export default function ProjectPage() {
   const [quickAddError, setQuickAddError] = useState<string | null>(null);
   const addSectionInputRef = useRef<HTMLInputElement | null>(null);
   const queryClient = useQueryClient();
-  const viewParam = (resolvedSearchParams.get('view') ?? 'list').toLowerCase();
-  const view: 'list' | 'board' | 'timeline' | 'gantt' | 'calendar' | 'files' =
-    viewParam === 'board'
-      || viewParam === 'timeline'
-      || viewParam === 'calendar'
-      || viewParam === 'files'
-      || viewParam === 'gantt'
-      ? (viewParam as 'list' | 'board' | 'timeline' | 'gantt' | 'calendar' | 'files')
-      : 'list';
+  const view = resolveProjectView(resolvedSearchParams.get('view'));
   const trashOpen = resolvedSearchParams.get('trash') === '1';
   const search = resolvedSearchParams.get('q') ?? '';
   const statusesParam = resolvedSearchParams.get('statuses');

--- a/apps/web-ui/src/components/layout/HeaderBar.tsx
+++ b/apps/web-ui/src/components/layout/HeaderBar.tsx
@@ -16,6 +16,7 @@ import { api } from '@/lib/api';
 import { queryKeys } from '@/lib/query-keys';
 import type { CustomFieldDefinition, Project, ProjectMember, Section, Task } from '@/lib/types';
 import { parseCustomFieldFilters, stringifyCustomFieldFilters, type CustomFieldFilter } from '@/lib/project-filters';
+import { PROJECT_VIEW_IDS, resolveProjectView, type ProjectViewId } from '@/lib/project-views';
 import { useI18n } from '@/lib/i18n';
 import { Input } from '@/components/ui/input';
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
@@ -240,10 +241,7 @@ export function HeaderBar({
     queryFn: () => api('/projects'),
   });
   const projectId = useMemo(() => pathname.match(/^\/projects\/([^/]+)/)?.[1] ?? null, [pathname]);
-  const currentView = (resolvedSearchParams.get('view') ?? 'list').toLowerCase();
-  const resolvedCurrentView = ['list', 'board', 'timeline', 'gantt', 'calendar', 'files'].includes(currentView)
-    ? currentView
-    : 'list';
+  const resolvedCurrentView = resolveProjectView(resolvedSearchParams.get('view'));
   const query = resolvedSearchParams.get('q') ?? '';
   const statusesParam = resolvedSearchParams.get('statuses');
   const assigneesParam = resolvedSearchParams.get('assignees');
@@ -261,15 +259,21 @@ export function HeaderBar({
     [customFieldFiltersParam],
   );
   const tabs = useMemo(
-    () =>
-      [
-        { id: 'list', label: t('list') },
-        { id: 'board', label: t('board') },
-        { id: 'timeline', label: t('timeline') },
-        { id: 'gantt', label: t('gantt') },
-        { id: 'calendar', label: t('calendar') },
-        { id: 'files', label: t('files') },
-      ] as const,
+    () => PROJECT_VIEW_IDS.map((id) => ({
+      id,
+      label:
+        id === 'list'
+          ? t('list')
+          : id === 'board'
+            ? t('board')
+            : id === 'timeline'
+              ? t('timeline')
+              : id === 'gantt'
+                ? t('gantt')
+                : id === 'calendar'
+                  ? t('calendar')
+                  : t('files'),
+    })) as Array<{ id: ProjectViewId; label: string }>,
     [t],
   );
 

--- a/apps/web-ui/src/lib/project-views.ts
+++ b/apps/web-ui/src/lib/project-views.ts
@@ -1,0 +1,10 @@
+export const PROJECT_VIEW_IDS = ['list', 'board', 'timeline', 'gantt', 'calendar', 'files'] as const;
+
+export type ProjectViewId = (typeof PROJECT_VIEW_IDS)[number];
+
+const PROJECT_VIEW_SET = new Set<string>(PROJECT_VIEW_IDS);
+
+export function resolveProjectView(rawView: string | null | undefined): ProjectViewId {
+  const normalized = (rawView ?? 'list').toLowerCase();
+  return PROJECT_VIEW_SET.has(normalized) ? (normalized as ProjectViewId) : 'list';
+}

--- a/e2e/playwright/tests/timeline-route.spec.ts
+++ b/e2e/playwright/tests/timeline-route.spec.ts
@@ -36,15 +36,15 @@ test('timeline and gantt routes are both supported and keep URL state', async ({
   const projectId = project.id as string;
 
   await page.goto(`/projects/${projectId}?view=timeline`);
-  await expect(page).toHaveURL(new RegExp(`/projects/${projectId}\\?view=timeline`));
+  await expect(page).toHaveURL(new RegExp(`/projects/${projectId}.*view=timeline`));
   await expect(page.locator('[data-testid="project-view-timeline"]')).toBeVisible();
   await expect(page.locator('[data-testid="timeline-view"]')).toBeVisible();
 
   await page.click('[data-testid="project-view-gantt"]');
-  await expect(page).toHaveURL(new RegExp(`/projects/${projectId}\\?view=gantt`));
+  await expect(page).toHaveURL(new RegExp(`/projects/${projectId}.*view=gantt`));
   await expect(page.locator('[data-testid="project-view-gantt"]')).toBeVisible();
   await expect(page.locator('[data-testid="timeline-view"]')).toBeVisible();
 
   await page.click('[data-testid="project-view-timeline"]');
-  await expect(page).toHaveURL(new RegExp(`/projects/${projectId}\\?view=timeline`));
+  await expect(page).toHaveURL(new RegExp(`/projects/${projectId}.*view=timeline`));
 });


### PR DESCRIPTION
## Summary
- split project view routing so `view=timeline` and `view=gantt` are both first-class values
- add a dedicated Timeline tab in project header while keeping Gantt tab
- remove forced timeline->gantt redirect and preserve URL state per selected tab
- update timeline route E2E to assert both timeline and gantt routes work

## Validation
- pnpm --filter @atlaspm/web-ui type-check
- pnpm --filter @atlaspm/web-ui lint
- pnpm e2e:up
- pnpm --filter @atlaspm/playwright exec playwright test tests/timeline-route.spec.ts tests/timeline.spec.ts
- pnpm e2e:down

Closes #175
