### PR TITLE
test: add timeline-gantt rollout regression gate

### DIFF
--- a/docs/ui/qa-regression-gates.md
+++ b/docs/ui/qa-regression-gates.md
@@ -14,6 +14,12 @@ pnpm -r --if-present build
 pnpm e2e
 ```
 
+For Timeline/Gantt split rollout gate, also run:
+
+```bash
+pnpm e2e:timeline-gantt-rollout
+```
+
 Notes:
 - `type-check` may be a no-op in some packages; keep command in the pipeline.
 - If Docker/Colima is down, start it first:
@@ -32,6 +38,9 @@ docker compose -f infra/docker/docker-compose.yml up -d
 - Assignee selection persists after refresh
 - Rule edit persists after refresh
 - Subtask tree create/expand/collapse/delete/navigation
+- Timeline-only controls do not leak into Gantt
+- Gantt-only controls do not leak into Timeline
+- List/rules/admin/collab regressions remain green during Timeline/Gantt changes
 
 ## Manual Smoke Checklist
 

--- a/docs/ui/timeline-gantt-rollout.md
+++ b/docs/ui/timeline-gantt-rollout.md
@@ -1,0 +1,65 @@
+# Timeline/Gantt Rollout Playbook (P5-5)
+
+This playbook defines the release gate for Timeline/Gantt split changes and the regression checks that must stay green before merge.
+
+## Purpose
+
+- Keep Timeline and Gantt responsibilities isolated.
+- Prevent regressions in critical adjacent flows: List, Rules, Admin, and Collaboration.
+- Leave an auditable rollout and rollback trail.
+
+## Required Validation
+
+Run from repository root:
+
+```bash
+pnpm -r --if-present lint
+pnpm -r --if-present type-check
+pnpm -r --if-present test
+pnpm -r --if-present build
+pnpm e2e:timeline-gantt-rollout
+```
+
+The focused rollout suite executes:
+
+- `tests/timeline-gantt-boundary.spec.ts`
+- `tests/timeline-route.spec.ts`
+- `tests/timeline-swimlane.spec.ts`
+- `tests/gantt-risk.spec.ts`
+- `tests/gantt-baseline.spec.ts`
+- `tests/list-deadline-sort.spec.ts`
+- `tests/rules.spec.ts`
+- `tests/admin.spec.ts`
+- `tests/collab.spec.ts`
+
+Use full-suite validation (`pnpm e2e`) for release candidates and after high-risk changes.
+
+## Rollout Steps
+
+1. Merge Timeline/Gantt split changes through PR only.
+2. Confirm CI + `pnpm e2e:timeline-gantt-rollout` are green.
+3. Smoke verify production-like environment:
+   - `/projects/:id?view=timeline`
+   - `/projects/:id?view=gantt`
+   - `/projects/:id?view=list`
+4. Monitor first deployment window for UI errors and E2E failures.
+5. Continue to full rollout only when no regressions are detected.
+
+## Metrics To Record Per Rollout
+
+- CI pass/fail for `lint`, `type-check`, `test`, `build`, `e2e`.
+- Focused rollout suite duration and failure count.
+- Number of rollback-triggering bugs in first 24h.
+- User-visible incidents related to:
+  - Timeline controls shown in Gantt
+  - Gantt controls shown in Timeline
+  - List deadline ordering
+  - Rules/Admin/Collab workflow breakage
+
+## Rollback Strategy
+
+1. Revert the offending PR(s) from `main`.
+2. Re-run:
+   - `pnpm -r --if-present test`
+   - `pnpm e2e:timeline-gantt-rollout`
+3. Redeploy only after focused suite is green.

--- a/e2e/playwright/tests/timeline-gantt-boundary.spec.ts
+++ b/e2e/playwright/tests/timeline-gantt-boundary.spec.ts
@@ -1,0 +1,105 @@
+import { expect, test } from '@playwright/test';
+
+const API = process.env.E2E_CORE_API_URL ?? 'http://localhost:3001';
+
+async function api(path: string, token: string, method = 'GET', body?: unknown) {
+  const res = await fetch(`${API}${path}`, {
+    method,
+    headers: {
+      'content-type': 'application/json',
+      authorization: `Bearer ${token}`,
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  if (!res.ok) throw new Error(`API ${res.status}: ${await res.text()}`);
+  const raw = await res.text();
+  return raw ? JSON.parse(raw) : null;
+}
+
+function dayIso(deltaDays: number) {
+  const date = new Date();
+  date.setUTCHours(0, 0, 0, 0);
+  date.setUTCDate(date.getUTCDate() + deltaDays);
+  return date.toISOString();
+}
+
+test('timeline and gantt controls stay isolated while list ordering remains stable', async ({ page }) => {
+  const now = Date.now();
+  const sub = `e2e-tl-gt-boundary-${now}`;
+  const email = `${sub}@example.com`;
+
+  await page.goto('/login');
+  await page.fill('input[placeholder="OIDC sub"]', sub);
+  await page.fill('input[placeholder="Email"]', email);
+  await page.click('button:has-text("Dev Login")');
+  await page.waitForURL('**/');
+
+  const token = await page.evaluate(() => localStorage.getItem('atlaspm_token') || '');
+  expect(token).toBeTruthy();
+
+  const workspaces = await api('/workspaces', token);
+  const workspaceId = workspaces[0].id as string;
+  const project = await api('/projects', token, 'POST', {
+    workspaceId,
+    name: `Timeline Gantt Boundary ${now}`,
+  });
+  const projectId = project.id as string;
+  const sections = await api(`/projects/${projectId}/sections`, token);
+  const defaultSection = sections.find((section: any) => section.isDefault) ?? sections[0];
+
+  const earlierTitle = `Boundary Earlier ${now}`;
+  const laterTitle = `Boundary Later ${now}`;
+
+  const earlierTask = await api(`/projects/${projectId}/tasks`, token, 'POST', {
+    sectionId: defaultSection.id,
+    title: earlierTitle,
+    startAt: dayIso(1),
+    dueAt: dayIso(2),
+  });
+  const laterTask = await api(`/projects/${projectId}/tasks`, token, 'POST', {
+    sectionId: defaultSection.id,
+    title: laterTitle,
+    startAt: dayIso(1),
+    dueAt: dayIso(7),
+  });
+  await api(`/tasks/${laterTask.id}/dependencies`, token, 'POST', {
+    dependsOnId: earlierTask.id,
+    type: 'BLOCKS',
+  });
+
+  await page.goto(`/projects/${projectId}?view=timeline`);
+  await expect(page.locator('[data-testid="timeline-view"]')).toBeVisible();
+  await expect(page.locator('[data-testid="timeline-swimlane-toggle"]')).toBeVisible();
+  await expect(page.locator('[data-testid="timeline-sort-toggle"]')).toBeVisible();
+  await expect(page.locator('[data-testid="timeline-schedule-filter-toggle"]')).toBeVisible();
+  await expect(page.locator('[data-testid="gantt-risk-filter-toggle"]')).toHaveCount(0);
+  await expect(page.locator('[data-testid="gantt-strict-mode"]')).toHaveCount(0);
+
+  await page.click('[data-testid="project-view-gantt"]');
+  await expect(page).toHaveURL(new RegExp(`/projects/${projectId}.*view=gantt`));
+  await expect(page.locator('[data-testid="timeline-view"]')).toBeVisible();
+  await expect(page.locator('[data-testid="gantt-risk-filter-toggle"]')).toBeVisible();
+  await expect(page.locator('[data-testid="gantt-strict-mode"]')).toBeVisible();
+  await expect(page.locator('[data-testid="timeline-swimlane-toggle"]')).toHaveCount(0);
+  await expect(page.locator('[data-testid="timeline-sort-toggle"]')).toHaveCount(0);
+
+  await page.click('[data-testid="project-view-list"]');
+  await expect(page).toHaveURL(new RegExp(`/projects/${projectId}.*view=list`));
+  await expect(page.locator(`[data-task-title="${earlierTitle}"]`)).toBeVisible();
+  await expect(page.locator(`[data-task-title="${laterTitle}"]`)).toBeVisible();
+
+  await expect
+    .poll(async () => {
+      const titlesInOrder = await page
+        .locator(`[data-testid="section-${defaultSection.id}"] [data-task-title]`)
+        .evaluateAll((elements) =>
+          elements
+            .map((element) => element.getAttribute('data-task-title') ?? '')
+            .filter(Boolean),
+        );
+      const earlierIndex = titlesInOrder.indexOf(earlierTitle);
+      const laterIndex = titlesInOrder.indexOf(laterTitle);
+      return earlierIndex >= 0 && laterIndex >= 0 ? earlierIndex < laterIndex : false;
+    })
+    .toBe(true);
+});

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "type-check:collab-server": "pnpm --filter @atlaspm/collab-server type-check",
     "e2e:up": "./scripts/e2e-up.sh",
     "e2e": "./scripts/run-e2e.sh",
+    "e2e:timeline-gantt-rollout": "./scripts/run-e2e.sh tests/timeline-gantt-boundary.spec.ts tests/timeline-route.spec.ts tests/timeline-swimlane.spec.ts tests/gantt-risk.spec.ts tests/gantt-baseline.spec.ts tests/list-deadline-sort.spec.ts tests/rules.spec.ts tests/admin.spec.ts tests/collab.spec.ts",
     "e2e:stability": "./scripts/e2e-stability.sh",
     "e2e:down": "./scripts/e2e-down.sh",
     "e2e:rebuild": "E2E_REBUILD=1 ./scripts/run-e2e.sh",

--- a/scripts/run-e2e.sh
+++ b/scripts/run-e2e.sh
@@ -48,4 +48,4 @@ cleanup() {
 }
 trap cleanup EXIT
 
-pnpm --filter @atlaspm/playwright e2e
+pnpm --filter @atlaspm/playwright e2e "$@"


### PR DESCRIPTION
## Summary
- add `tests/timeline-gantt-boundary.spec.ts` to verify Timeline/Gantt responsibility isolation and list ordering stability after view switching
- add `pnpm e2e:timeline-gantt-rollout` regression gate command for Timeline/Gantt + list/rules/admin/collab
- allow `scripts/run-e2e.sh` to forward specific test paths to Playwright
- add rollout/metrics playbook at `docs/ui/timeline-gantt-rollout.md`
- update QA regression gates with Timeline/Gantt split checks

Closes #179

## Why
Finalizing the Timeline/Gantt split requires an explicit regression gate and rollout protocol so adjacent flows (list, rules, admin, collab) remain protected while the new split behavior is validated.

## Verification Commands
- `pnpm --filter @atlaspm/playwright e2e tests/timeline-gantt-boundary.spec.ts`
- `pnpm e2e:timeline-gantt-rollout`
- `docker compose -f infra/docker/docker-compose.yml up -d postgres && pnpm test`
- `pnpm -r --if-present lint`
- `pnpm -r --if-present type-check`
- `pnpm -r --if-present build`

## Risks / Known Gaps
- Rollout suite is focused; full-suite `pnpm e2e` should still be run for release candidates.
- Local environment uses Node `v24` while project engine target is Node `20`.

## Rollback Plan
- Revert this PR to remove the new gate command/test/doc updates.
- Re-run existing baseline checks (`pnpm test`, `pnpm e2e`) before redeploy.