### PR TITLE
feat(timeline): move unscheduled tasks into tray

### DIFF
--- a/apps/web-ui/src/lib/i18n.tsx
+++ b/apps/web-ui/src/lib/i18n.tsx
@@ -602,7 +602,7 @@ const dictionaries: Record<Locale, Dictionary> = {
     timelineViewStateSaveFailed: 'タイムライン表示設定の保存に失敗しました。最新の表示に戻しました。',
     timelineScheduledTasks: '予定あり',
     timelineUnscheduled: '未設定',
-    timelineUnscheduledTrayHint: 'このタスクをタイムラインへドラッグして日付を割り当てます。',
+    timelineUnscheduledTrayHint: 'これらのタスクをタイムラインへドラッグして日付を割り当てます。',
     timelineDependencies: '依存関係',
     timelineZoomDay: '日',
     timelineZoomWeek: '週',

--- a/packages/domain/src/__tests__/timeline-layout.test.ts
+++ b/packages/domain/src/__tests__/timeline-layout.test.ts
@@ -113,6 +113,40 @@ test('buildTimelineLanes respects preferred section order', () => {
   );
 });
 
+test('buildTimelineLanes keeps empty sections visible and ordered by preference', () => {
+  const tasks: TaskInput[] = [
+    {
+      id: 'task-1',
+      title: 'Design task',
+      sectionId: 'design',
+      assigneeUserId: null,
+      status: 'TODO',
+      hasSchedule: false,
+      inWindow: false,
+      timelineStart: null,
+      timelineEnd: null,
+    },
+  ];
+
+  const lanes = buildTimelineLanes({
+    swimlane: 'section',
+    tasks,
+    sections,
+    membersById: {},
+    preferredLaneOrder: ['section:default', 'section:design'],
+    defaultSectionLabel: 'Tasks',
+    unassignedLabel: 'Unassigned',
+  });
+
+  assert.deepEqual(
+    lanes.map((lane) => ({ id: lane.id, taskCount: lane.tasks.length })),
+    [
+      { id: 'section:default', taskCount: 0 },
+      { id: 'section:design', taskCount: 1 },
+    ],
+  );
+});
+
 test('buildTimelineLanes groups status lanes in fixed workflow order', () => {
   const tasks: TaskInput[] = [
     {
@@ -210,7 +244,6 @@ test('buildTimelineLayout calculates row and bar positions', () => {
   });
 
   const designLane = layout.lanesWithRows.find((lane) => lane.lane.id === 'section:design');
-
   assert.equal(layout.bodyHeight, 104);
   assert.equal(layout.totalRowCount, 3);
   assert.deepEqual(layout.taskRowsById['task-1'], { top: 64, height: 40 });


### PR DESCRIPTION
## Summary
- move unscheduled Timeline tasks out of inline swimlane rows and into a dedicated tray
- keep empty section lanes visible so they remain valid drop targets
- cover the new tray behavior in Timeline Playwright coverage

## Linked Issue
- Closes #201

## Validation
- pnpm --filter @atlaspm/web-ui type-check
- cd e2e/playwright && E2E_BASE_URL=http://localhost:3100 pnpm exec playwright test tests/timeline-swimlane.spec.ts --reporter=list

## Base Branch
- stacked on #219 / `codex/timeline-p1-1-swimlane-grouping`

## Notes
- empty placeholder lanes are only rendered for section swimlanes in this wave; assignee/status empty-lane UX remains deferred