### PR TITLE
feat(timeline): compact non-overlapping lane rows

### DIFF
--- a/packages/domain/src/__tests__/timeline-layout.test.ts
+++ b/packages/domain/src/__tests__/timeline-layout.test.ts
@@ -275,15 +275,13 @@ test('buildTimelineLayout compacts non-overlapping tasks into shared rows', () =
     compactRows: true,
   });
 
-  const designLane = layout.lanesWithRows.find((lane) => lane.lane.id === 'section:design');
-
-  assert.equal(layout.bodyHeight, 144);
-  assert.equal(layout.totalRowCount, 4);
-  assert.equal(designLane?.rows.length, 2);
-  assert.deepEqual(layout.taskRowsById['task-1'], { top: 64, height: 40 });
-  assert.deepEqual(layout.taskRowsById['task-2'], { top: 64, height: 40 });
-  assert.deepEqual(layout.taskRowsById['task-3'], { top: 104, height: 40 });
-  assert.deepEqual(designLane?.rows.map((row) => ({ index: row.index, taskIds: row.tasks.map((task) => task.id) })), [
+  assert.equal(layout.bodyHeight, 112);
+  assert.equal(layout.totalRowCount, 3);
+  assert.equal(layout.lanesWithRows[0]?.rows.length, 2);
+  assert.deepEqual(layout.taskRowsById['task-1'], { top: 32, height: 40 });
+  assert.deepEqual(layout.taskRowsById['task-2'], { top: 32, height: 40 });
+  assert.deepEqual(layout.taskRowsById['task-3'], { top: 72, height: 40 });
+  assert.deepEqual(layout.lanesWithRows[0]?.rows.map((row) => ({ index: row.index, taskIds: row.tasks.map((task) => task.id) })), [
     { index: 0, taskIds: ['task-1', 'task-2'] },
     { index: 1, taskIds: ['task-3'] },
   ]);


### PR DESCRIPTION
## Summary
- compact non-overlapping scheduled Timeline tasks into shared swimlane rows
- keep Gantt on strict one-row-per-task behavior
- cover the new packing behavior in domain tests and Timeline Playwright coverage

## Linked Issue
- Closes #202

## Validation
- pnpm --filter @atlaspm/domain build
- node --test packages/domain/dist/__tests__/timeline-layout.test.js
- pnpm --filter @atlaspm/web-ui type-check
- cd e2e/playwright && E2E_BASE_URL=http://localhost:3101 pnpm exec playwright test tests/timeline-swimlane.spec.ts --reporter=list

## Base Branch
- stacked on #220 / `codex/timeline-p1-3-unscheduled-tray`

## Notes
- compact packing currently uses schedule interval overlap only; dependency-aware auto-layout remains for later work