### PR TITLE
Timeline P0-2: remove task-name lane lists from assignee/status views (#229)

### DIFF
--- a/apps/web-ui/src/components/project-timeline-view.tsx
+++ b/apps/web-ui/src/components/project-timeline-view.tsx
@@ -2816,7 +2816,11 @@ export function ProjectScheduleCanvas({
                   data-testid={`timeline-lane-${normalizeTestIdSegment(lane.id)}`}
                   data-timeline-lane-id={lane.id}
                 >
-                  <div className={showHeaderOnlyLaneRail ? 'relative' : 'border-r bg-muted/10'}>
+                  <div
+                    className={
+                      showHeaderOnlyLaneRail ? 'relative self-start' : 'border-r bg-muted/10'
+                    }
+                  >
                     <div
                       className={showHeaderOnlyLaneRail ? 'w-full border-r bg-muted/10' : undefined}
                       data-testid={`timeline-lane-rail-${normalizeTestIdSegment(lane.id)}`}

--- a/e2e/playwright/tests/timeline-swimlane.spec.ts
+++ b/e2e/playwright/tests/timeline-swimlane.spec.ts
@@ -48,6 +48,26 @@ function laneRailTestId(laneTestId: string) {
   return laneTestId.replace('timeline-lane-', 'timeline-lane-rail-');
 }
 
+async function expectHeaderOnlyRail(page: Page, laneTestId: string, forbiddenTaskTitles: string[]) {
+  const laneHeader = page.locator(`[data-testid="${laneHeaderTestId(laneTestId)}"]`);
+  const laneRail = page.locator(`[data-testid="${laneRailTestId(laneTestId)}"]`);
+  await expect(laneHeader).toBeVisible();
+  await expect(laneRail).toHaveAttribute('data-header-only', 'true');
+  for (const taskTitle of forbiddenTaskTitles) {
+    await expect(laneRail).not.toContainText(taskTitle);
+  }
+
+  const [headerBox, railBox, childElementCount] = await Promise.all([
+    laneHeader.boundingBox(),
+    laneRail.boundingBox(),
+    laneRail.evaluate((element) => element.childElementCount),
+  ]);
+  expect(headerBox).toBeTruthy();
+  expect(railBox).toBeTruthy();
+  expect(childElementCount).toBe(1);
+  expect(Math.abs((railBox?.height ?? 0) - (headerBox?.height ?? 0))).toBeLessThanOrEqual(1);
+}
+
 async function dragTimelineLaneHeaderToLane(
   page: Page,
   draggingLaneTestId: string,
@@ -213,12 +233,7 @@ test('timeline supports swimlane toggle and due-date sort without affecting gant
   );
   const assigneeLaneTestId = `timeline-lane-assignee-${sub}`;
   await expect(page.locator('[data-testid^="timeline-lane-assignee-"]')).toHaveCount(1);
-  const assigneeHeader = page.locator(`[data-testid="${laneHeaderTestId(assigneeLaneTestId)}"]`);
-  await expect(assigneeHeader).toBeVisible();
-  const assigneeRail = page.locator(`[data-testid="${laneRailTestId(assigneeLaneTestId)}"]`);
-  await expect(assigneeRail).toHaveAttribute('data-header-only', 'true');
-  await expect(assigneeRail).not.toContainText(taskLate.title);
-  await expect(assigneeRail).not.toContainText(taskEarly.title);
+  await expectHeaderOnlyRail(page, assigneeLaneTestId, [taskLate.title, taskEarly.title]);
 
   await page.click('[data-testid="timeline-swimlane-status"]');
   await expect(page.locator('[data-testid="timeline-swimlane-status"]')).toHaveAttribute(
@@ -227,12 +242,7 @@ test('timeline supports swimlane toggle and due-date sort without affecting gant
   );
   await expect(page.locator('[data-testid^="timeline-lane-status-"]')).toHaveCount(2);
   for (const laneTestId of ['timeline-lane-status-IN_PROGRESS', 'timeline-lane-status-BLOCKED']) {
-    const laneHeader = page.locator(`[data-testid="${laneHeaderTestId(laneTestId)}"]`);
-    await expect(laneHeader).toBeVisible();
-    const laneRail = page.locator(`[data-testid="${laneRailTestId(laneTestId)}"]`);
-    await expect(laneRail).toHaveAttribute('data-header-only', 'true');
-    await expect(laneRail).not.toContainText(taskLate.title);
-    await expect(laneRail).not.toContainText(taskEarly.title);
+    await expectHeaderOnlyRail(page, laneTestId, [taskLate.title, taskEarly.title]);
   }
 
   await page.click('[data-testid="timeline-filter-unscheduled"]');


### PR DESCRIPTION
Closes #229
This PR was opened by atlaspm-supervisor.
Latest Codex summary:

The branch already contains the issue implementation in [project-timeline-view.tsx](/Users/tomoakikawada/Dev/atlaspm-worktrees/issue-229/apps/web-ui/src/components/project-timeline-view.tsx) and the focused coverage in [timeline-swimlane.spec.ts](/Users/tomoakikawada/Dev/atlaspm-worktrees/issue-229/e2e/playwright/tests/timeline-swimlane.spec.ts). I verified the assignee/status rails stay header-only and that the timeline canvas remains the sole place tasks are rendered/manipulated. No additional code change or commit was needed in this turn.

Summary: Verified issue #229 is already implemented on `codex/issue-229`; no new code changes were required.
State hint: implementing
Tests: `pnpm type-check:web-ui`; `./scripts/run-e2e.sh tests/timeline-swimlane.spec.ts`
Next action: Open a PR for `codex/issue-229` or continue to the next queued issue once this branch is handed off.