### PR TITLE
Timeline P2-1: prefer manual placement over auto packing with explicit Align action

### DIFF
--- a/apps/web-ui/src/components/project-timeline-view.tsx
+++ b/apps/web-ui/src/components/project-timeline-view.tsx
@@ -1,7 +1,11 @@
 'use client';
 
 import { useEffect, useId, useMemo, useRef, useState, type CSSProperties } from 'react';
-import { buildTimelineLanes, buildTimelineLayout } from '@atlaspm/domain';
+import {
+  buildTimelineLanes,
+  buildTimelineLayout,
+  buildTimelineTaskOrderByLane,
+} from '@atlaspm/domain';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { ChevronDown, ChevronLeft, ChevronRight } from 'lucide-react';
 import TaskDetailDrawer from '@/components/task-detail-drawer';
@@ -607,6 +611,17 @@ function hasTimelineManualLayout(layout: TimelineManualLayoutByLane): boolean {
   return Object.values(layout).some((laneTaskOrder) => laneTaskOrder.length > 0);
 }
 
+function mergeTimelineManualLaneTaskOrder(
+  existingTaskOrder: string[] | undefined,
+  nextTaskOrder: string[],
+): string[] {
+  const seenTaskIds = new Set(nextTaskOrder);
+  return [
+    ...nextTaskOrder,
+    ...(existingTaskOrder ?? []).filter((taskId) => !seenTaskIds.has(taskId)),
+  ];
+}
+
 function readStoredTimelineLaneOrder(keys: Array<string | null | undefined>): string[] {
   if (typeof window === 'undefined') return [];
   for (const key of keys) {
@@ -690,7 +705,6 @@ export function ProjectScheduleCanvas({
   const [sortMode, setSortMode] = useState<TimelineSortMode>('manual');
   const [scheduleFilter, setScheduleFilter] = useState<TimelineScheduleFilter>('all');
   const [workingDaysOnly, setWorkingDaysOnly] = useState(false);
-  const [dependencyAwarePacking, setDependencyAwarePacking] = useState(false);
   const [ganttRiskFilterMode, setGanttRiskFilterMode] = useState<GanttRiskFilterMode>('all');
   const [ganttStrictMode, setGanttStrictMode] = useState(false);
   const [preferencesHydrated, setPreferencesHydrated] = useState(false);
@@ -1844,11 +1858,9 @@ export function ProjectScheduleCanvas({
       taskRowHeight: TASK_ROW_HEIGHT,
       compactRows: mode === 'timeline',
       manualRowLaneIds: mode === 'timeline' ? manualLayoutLaneIds : [],
-      dependencyAwarePacking: mode === 'timeline' && dependencyAwarePacking,
       dependencyEdges: timeline.dependencyEdges,
     });
   }, [
-    dependencyAwarePacking,
     manualLayoutLaneIds,
     mode,
     timeline.dependencyEdges,
@@ -1857,6 +1869,43 @@ export function ProjectScheduleCanvas({
     visibleTimelineLanes,
     zoomConfig.dayColWidth,
   ]);
+
+  const alignTimeline = () => {
+    if (mode !== 'timeline') return;
+    const expandedTimelineLanes = timelineLanes.filter((lane) => !collapsedLaneIds.has(lane.id));
+    if (!expandedTimelineLanes.length) return;
+
+    const alignedLaneTaskOrder = buildTimelineTaskOrderByLane({
+      lanes: expandedTimelineLanes,
+      windowStart: timeline.window.start,
+      windowEnd: timeline.window.end,
+      dayColumnWidth: zoomConfig.dayColWidth,
+      sectionRowHeight: SECTION_ROW_HEIGHT,
+      taskRowHeight: TASK_ROW_HEIGHT,
+      compactRows: true,
+      dependencyAwarePacking: true,
+      dependencyEdges: timeline.dependencyEdges,
+    });
+
+    const nextManualLayout = { ...preferredManualLayout };
+    for (const lane of expandedTimelineLanes) {
+      const alignedTaskOrder = alignedLaneTaskOrder[lane.id];
+      if (!alignedTaskOrder?.length) continue;
+      nextManualLayout[lane.id] = mergeTimelineManualLaneTaskOrder(
+        preferredManualLayout[lane.id],
+        alignedTaskOrder,
+      );
+    }
+
+    if (JSON.stringify(nextManualLayout) === JSON.stringify(preferredManualLayout)) {
+      return;
+    }
+
+    saveManualLayoutMutation.mutate({
+      groupBy: effectiveSwimlane,
+      laneTaskOrder: nextManualLayout,
+    });
+  };
 
   useEffect(() => {
     const container = scrollContainerRef.current;
@@ -2753,11 +2802,12 @@ export function ProjectScheduleCanvas({
             <Button
               type="button"
               size="sm"
-              variant={dependencyAwarePacking ? 'default' : 'outline'}
+              variant="outline"
               className="h-7 px-2 text-xs"
               data-testid="timeline-align-toggle"
-              data-active={dependencyAwarePacking ? 'true' : 'false'}
-              onClick={() => setDependencyAwarePacking((current) => !current)}
+              data-active="false"
+              onClick={alignTimeline}
+              disabled={saveManualLayoutMutation.isPending}
               title={t('timelineAlignHint')}
             >
               {t('timelineAlign')}

--- a/e2e/playwright/tests/timeline.spec.ts
+++ b/e2e/playwright/tests/timeline.spec.ts
@@ -551,7 +551,7 @@ test('timeline working-days drag skips weekends and Alt keeps calendar-day place
     .toBe(saturday.toISOString());
 });
 
-test('timeline align toggle repacks dependency chains ahead of unrelated blockers', async ({
+test('timeline align action saves dependency chains ahead of unrelated blockers', async ({
   page,
 }) => {
   const now = Date.now();
@@ -614,11 +614,16 @@ test('timeline align toggle repacks dependency chains ahead of unrelated blocker
   }
   expect(beforeChainABox.y).toBeGreaterThan(beforeBlockerBox.y);
 
-  await page.click('[data-testid="timeline-align-toggle"]');
-  await expect(page.locator('[data-testid="timeline-align-toggle"]')).toHaveAttribute(
-    'data-active',
-    'true',
-  );
+  await Promise.all([
+    page.waitForResponse(
+      (response) =>
+        response.request().method() === 'PUT' &&
+        response.url().includes(
+          `/projects/${projectId}/timeline/preferences/manual-layout/section`,
+        ),
+    ),
+    page.click('[data-testid="timeline-align-toggle"]'),
+  ]);
 
   await expect
     .poll(async () => {
@@ -633,9 +638,49 @@ test('timeline align toggle repacks dependency chains ahead of unrelated blocker
         chainBY: Math.round(nextChainBBox?.y ?? -1),
       };
     })
-    .toEqual({
-      blockerY: Math.round(beforeChainABox.y),
+    .toMatchObject({
       chainAY: Math.round(beforeBlockerBox.y),
-      chainBY: Math.round(beforeBlockerBox.y),
+      chainBY: Math.round(beforeChainABox.y),
     });
+
+  await expect
+    .poll(async () => {
+      const [nextBlockerBox, nextChainBBox] = await Promise.all([
+        blockerBar.boundingBox(),
+        chainBBar.boundingBox(),
+      ]);
+      return Math.round((nextBlockerBox?.y ?? -1) - (nextChainBBox?.y ?? -1));
+    })
+    .toBeGreaterThan(0);
+
+  await page.reload();
+  await expect(page.locator('[data-testid="timeline-view"]')).toBeVisible();
+
+  await expect
+    .poll(async () => {
+      const [nextBlockerBox, nextChainABox, nextChainBBox] = await Promise.all([
+        blockerBar.boundingBox(),
+        chainABar.boundingBox(),
+        chainBBar.boundingBox(),
+      ]);
+      return {
+        blockerY: Math.round(nextBlockerBox?.y ?? -1),
+        chainAY: Math.round(nextChainABox?.y ?? -1),
+        chainBY: Math.round(nextChainBBox?.y ?? -1),
+      };
+    })
+    .toMatchObject({
+      chainAY: Math.round(beforeBlockerBox.y),
+      chainBY: Math.round(beforeChainABox.y),
+    });
+
+  await expect
+    .poll(async () => {
+      const [nextBlockerBox, nextChainBBox] = await Promise.all([
+        blockerBar.boundingBox(),
+        chainBBar.boundingBox(),
+      ]);
+      return Math.round((nextBlockerBox?.y ?? -1) - (nextChainBBox?.y ?? -1));
+    })
+    .toBeGreaterThan(0);
 });

--- a/packages/domain/src/__tests__/timeline-layout.test.ts
+++ b/packages/domain/src/__tests__/timeline-layout.test.ts
@@ -3,6 +3,7 @@ import test from 'node:test';
 import {
   buildTimelineLanes,
   buildTimelineLayout,
+  buildTimelineTaskOrderByLane,
   type TimelineLaneTaskInput,
   type TimelineSectionInput,
 } from '../services/timeline-layout.js';
@@ -466,6 +467,75 @@ test('buildTimelineLayout keeps manual-layout lanes expanded while compacting ot
   assert.equal(defaultLane?.rows.length, 1);
 });
 
+test('buildTimelineLayout keeps manual task order authoritative over dependency packing', () => {
+  const layout = buildTimelineLayout({
+    lanes: [
+      {
+        id: 'section:design',
+        label: 'Design',
+        tasks: [
+          {
+            id: 'task-blocker',
+            title: 'Manual blocker first',
+            sectionId: 'design',
+            assigneeUserId: 'user-1',
+            status: 'TODO',
+            hasSchedule: true,
+            inWindow: true,
+            timelineStart: utcDate('2026-03-02'),
+            timelineEnd: utcDate('2026-03-10'),
+          },
+          {
+            id: 'task-chain-a',
+            title: 'Chain start',
+            sectionId: 'design',
+            assigneeUserId: 'user-1',
+            status: 'IN_PROGRESS',
+            hasSchedule: true,
+            inWindow: true,
+            timelineStart: utcDate('2026-03-05'),
+            timelineEnd: utcDate('2026-03-06'),
+          },
+          {
+            id: 'task-chain-b',
+            title: 'Chain follow-up',
+            sectionId: 'design',
+            assigneeUserId: 'user-1',
+            status: 'TODO',
+            hasSchedule: true,
+            inWindow: true,
+            timelineStart: utcDate('2026-03-07'),
+            timelineEnd: utcDate('2026-03-08'),
+          },
+        ],
+      },
+    ],
+    windowStart: utcDate('2026-03-01'),
+    windowEnd: utcDate('2026-03-10'),
+    dayColumnWidth: 20,
+    sectionRowHeight: 32,
+    taskRowHeight: 40,
+    compactRows: true,
+    manualRowLaneIds: ['section:design'],
+    dependencyAwarePacking: true,
+    dependencyEdges: [{ source: 'task-chain-a', target: 'task-chain-b', type: 'BLOCKS' }],
+  });
+
+  const designLane = layout.lanesWithRows[0];
+
+  assert.deepEqual(
+    designLane?.rows.map((row) => ({ index: row.index, taskIds: row.tasks.map((task) => task.id) })),
+    [
+      { index: 0, taskIds: ['task-blocker'] },
+      { index: 1, taskIds: ['task-chain-a'] },
+      { index: 2, taskIds: ['task-chain-b'] },
+    ],
+  );
+  assert.equal(layout.taskRowsById['task-blocker']?.top, 32);
+  assert.equal(layout.taskRowsById['task-chain-a']?.top, 72);
+  assert.equal(layout.taskRowsById['task-chain-b']?.top, 112);
+});
+
 test('buildTimelineLayout keeps input order inside compact rows', () => {
   const tasks: TaskInput[] = [
     {
@@ -573,4 +643,67 @@ test('buildTimelineLayout can align dependency chains ahead of unrelated blocker
   assert.equal(alignedLayout.taskRowsById['task-chain-a']?.top, 32);
   assert.equal(alignedLayout.taskRowsById['task-chain-b']?.top, 32);
   assert.equal(alignedLayout.taskRowsById['task-blocker']?.top, 72);
+});
+
+test('buildTimelineTaskOrderByLane returns explicit aligned order for visible lanes', () => {
+  const laneTaskOrder = buildTimelineTaskOrderByLane({
+    lanes: [
+      {
+        id: 'section:design',
+        label: 'Design',
+        tasks: [
+          {
+            id: 'task-chain-b',
+            title: 'Chain follow-up',
+            sectionId: 'design',
+            assigneeUserId: 'user-1',
+            status: 'TODO',
+            hasSchedule: true,
+            inWindow: true,
+            timelineStart: utcDate('2026-03-07'),
+            timelineEnd: utcDate('2026-03-08'),
+          },
+          {
+            id: 'task-chain-a',
+            title: 'Chain start',
+            sectionId: 'design',
+            assigneeUserId: 'user-1',
+            status: 'IN_PROGRESS',
+            hasSchedule: true,
+            inWindow: true,
+            timelineStart: utcDate('2026-03-05'),
+            timelineEnd: utcDate('2026-03-06'),
+          },
+          {
+            id: 'task-blocker',
+            title: 'Long blocker',
+            sectionId: 'design',
+            assigneeUserId: 'user-1',
+            status: 'TODO',
+            hasSchedule: true,
+            inWindow: true,
+            timelineStart: utcDate('2026-03-02'),
+            timelineEnd: utcDate('2026-03-10'),
+          },
+        ],
+      },
+      {
+        id: 'section:empty',
+        label: 'Empty',
+        tasks: [],
+      },
+    ],
+    windowStart: utcDate('2026-03-01'),
+    windowEnd: utcDate('2026-03-10'),
+    dayColumnWidth: 20,
+    sectionRowHeight: 32,
+    taskRowHeight: 40,
+    compactRows: true,
+    dependencyAwarePacking: true,
+    dependencyEdges: [{ source: 'task-chain-a', target: 'task-chain-b', type: 'BLOCKS' }],
+  });
+
+  assert.deepEqual(laneTaskOrder, {
+    'section:design': ['task-chain-a', 'task-chain-b', 'task-blocker'],
+  });
 });

--- a/packages/domain/src/services/timeline-layout.ts
+++ b/packages/domain/src/services/timeline-layout.ts
@@ -94,6 +94,13 @@ export type BuildTimelineLayoutInput<TTask extends TimelineLayoutTaskInput> = {
   dependencyEdges?: Array<{ source: string; target: string; type?: string }>;
 };
 
+export type TimelineTaskOrderByLane = Record<string, string[]>;
+
+type CompactRowPlacement = {
+  rowIndexByTaskId: Record<string, number>;
+  packingOrderByTaskId: Map<string, number>;
+};
+
 const DEFAULT_UNASSIGNED_LANE_ID = '__unassigned__';
 
 function dayNumber(date: Date): number {
@@ -169,6 +176,144 @@ function applyTaskOrder<TTask extends { id: string }>(
     if (leftRank !== rightRank) return leftRank - rightRank;
     return (fallbackTaskOrder.get(left.id) ?? 0) - (fallbackTaskOrder.get(right.id) ?? 0);
   });
+}
+
+function buildCompactRowPlacement<TTask extends TimelineLayoutTaskInput>(
+  tasks: TTask[],
+  dependencyAwarePacking: boolean | undefined,
+  dependencyEdges: Array<{ source: string; target: string; type?: string }> | undefined,
+): CompactRowPlacement {
+  const rowIndexByTaskId: Record<string, number> = {};
+  const laneTaskIds = new Set(tasks.map((task) => task.id));
+  const relevantDependencyEdges = dependencyAwarePacking
+    ? (dependencyEdges ?? []).filter(
+        (edge) =>
+          edge.type !== 'RELATES_TO' && laneTaskIds.has(edge.source) && laneTaskIds.has(edge.target),
+      )
+    : [];
+  const incomingByTaskId = new Map<string, Set<string>>();
+  const outgoingByTaskId = new Map<string, Set<string>>();
+  const undirectedByTaskId = new Map<string, Set<string>>();
+  for (const task of tasks) {
+    incomingByTaskId.set(task.id, new Set());
+    outgoingByTaskId.set(task.id, new Set());
+    undirectedByTaskId.set(task.id, new Set());
+  }
+  for (const edge of relevantDependencyEdges) {
+    incomingByTaskId.get(edge.target)?.add(edge.source);
+    outgoingByTaskId.get(edge.source)?.add(edge.target);
+    undirectedByTaskId.get(edge.source)?.add(edge.target);
+    undirectedByTaskId.get(edge.target)?.add(edge.source);
+  }
+
+  const componentSizeByTaskId = new Map<string, number>();
+  const visited = new Set<string>();
+  for (const task of tasks) {
+    if (visited.has(task.id)) continue;
+    const stack = [task.id];
+    const component: string[] = [];
+    visited.add(task.id);
+    while (stack.length) {
+      const current = stack.pop()!;
+      component.push(current);
+      for (const neighbor of undirectedByTaskId.get(current) ?? []) {
+        if (visited.has(neighbor)) continue;
+        visited.add(neighbor);
+        stack.push(neighbor);
+      }
+    }
+    for (const taskId of component) {
+      componentSizeByTaskId.set(taskId, component.length);
+    }
+  }
+
+  const fallbackTaskCompare = (left: TTask, right: TTask) => {
+    const leftStart = left.timelineStart ? dayNumber(left.timelineStart) : Number.MAX_SAFE_INTEGER;
+    const rightStart = right.timelineStart ? dayNumber(right.timelineStart) : Number.MAX_SAFE_INTEGER;
+    if (leftStart !== rightStart) return leftStart - rightStart;
+    const leftEnd = left.timelineEnd ? dayNumber(left.timelineEnd) : Number.MAX_SAFE_INTEGER;
+    const rightEnd = right.timelineEnd ? dayNumber(right.timelineEnd) : Number.MAX_SAFE_INTEGER;
+    if (leftEnd !== rightEnd) return leftEnd - rightEnd;
+    return left.id.localeCompare(right.id);
+  };
+
+  const taskById = new Map(tasks.map((task) => [task.id, task] as const));
+  const indegreeByTaskId = new Map<string, number>();
+  const depthByTaskId = new Map<string, number>();
+  for (const task of tasks) {
+    indegreeByTaskId.set(task.id, incomingByTaskId.get(task.id)?.size ?? 0);
+    depthByTaskId.set(task.id, 0);
+  }
+
+  const queue = [...tasks]
+    .filter((task) => (indegreeByTaskId.get(task.id) ?? 0) === 0)
+    .sort(fallbackTaskCompare);
+  while (queue.length) {
+    const current = queue.shift()!;
+    const currentDepth = depthByTaskId.get(current.id) ?? 0;
+    for (const targetTaskId of outgoingByTaskId.get(current.id) ?? []) {
+      depthByTaskId.set(targetTaskId, Math.max(depthByTaskId.get(targetTaskId) ?? 0, currentDepth + 1));
+      const nextInDegree = (indegreeByTaskId.get(targetTaskId) ?? 0) - 1;
+      indegreeByTaskId.set(targetTaskId, nextInDegree);
+      if (nextInDegree === 0) {
+        const nextTask = taskById.get(targetTaskId);
+        if (nextTask) {
+          queue.push(nextTask);
+          queue.sort(fallbackTaskCompare);
+        }
+      }
+    }
+  }
+
+  const tasksForPacking = [...tasks].sort((left, right) => {
+    if (dependencyAwarePacking) {
+      const leftComponentSize = componentSizeByTaskId.get(left.id) ?? 1;
+      const rightComponentSize = componentSizeByTaskId.get(right.id) ?? 1;
+      if (leftComponentSize !== rightComponentSize) return rightComponentSize - leftComponentSize;
+      const leftDepth = depthByTaskId.get(left.id) ?? 0;
+      const rightDepth = depthByTaskId.get(right.id) ?? 0;
+      if (leftDepth !== rightDepth) return leftDepth - rightDepth;
+    }
+    return fallbackTaskCompare(left, right);
+  });
+
+  const activeRows: Array<{ rowIndex: number; endDay: number }> = [];
+  const availableRowIndexes: number[] = [];
+  let nextRowIndex = 0;
+
+  for (const task of tasksForPacking) {
+    let rowIndex: number;
+    if (task.hasSchedule && task.inWindow && task.timelineStart && task.timelineEnd) {
+      const taskStartDay = dayNumber(task.timelineStart);
+      const taskEndDay = dayNumber(task.timelineEnd);
+
+      while (activeRows.length && activeRows[0]!.endDay < taskStartDay) {
+        const released = popHeap(
+          activeRows,
+          (left, right) => left.endDay - right.endDay || left.rowIndex - right.rowIndex,
+        );
+        if (released) {
+          pushHeap(availableRowIndexes, released.rowIndex, (left, right) => left - right);
+        }
+      }
+
+      rowIndex = popHeap(availableRowIndexes, (left, right) => left - right) ?? nextRowIndex++;
+      pushHeap(
+        activeRows,
+        { rowIndex, endDay: taskEndDay },
+        (left, right) => left.endDay - right.endDay || left.rowIndex - right.rowIndex,
+      );
+    } else {
+      rowIndex = nextRowIndex++;
+    }
+
+    rowIndexByTaskId[task.id] = rowIndex;
+  }
+
+  return {
+    rowIndexByTaskId,
+    packingOrderByTaskId: new Map(tasksForPacking.map((task, index) => [task.id, index])),
+  };
 }
 
 export function buildTimelineLanes<TTask extends TimelineLaneTaskInput>(
@@ -286,122 +431,14 @@ export function buildTimelineLayout<TTask extends TimelineLayoutTaskInput>(
     const laneUsesManualRows = manualRowLaneIds.has(lane.id);
 
     if (input.compactRows && !laneUsesManualRows) {
-      const laneTaskIds = new Set(lane.tasks.map((task) => task.id));
-      const relevantDependencyEdges = input.dependencyAwarePacking
-        ? (input.dependencyEdges ?? []).filter((edge) =>
-            edge.type !== 'RELATES_TO' && laneTaskIds.has(edge.source) && laneTaskIds.has(edge.target))
-        : [];
-      const incomingByTaskId = new Map<string, Set<string>>();
-      const outgoingByTaskId = new Map<string, Set<string>>();
-      const undirectedByTaskId = new Map<string, Set<string>>();
-      for (const task of lane.tasks) {
-        incomingByTaskId.set(task.id, new Set());
-        outgoingByTaskId.set(task.id, new Set());
-        undirectedByTaskId.set(task.id, new Set());
-      }
-      for (const edge of relevantDependencyEdges) {
-        incomingByTaskId.get(edge.target)?.add(edge.source);
-        outgoingByTaskId.get(edge.source)?.add(edge.target);
-        undirectedByTaskId.get(edge.source)?.add(edge.target);
-        undirectedByTaskId.get(edge.target)?.add(edge.source);
-      }
-
-      const componentSizeByTaskId = new Map<string, number>();
-      const visited = new Set<string>();
-      for (const task of lane.tasks) {
-        if (visited.has(task.id)) continue;
-        const stack = [task.id];
-        const component: string[] = [];
-        visited.add(task.id);
-        while (stack.length) {
-          const current = stack.pop()!;
-          component.push(current);
-          for (const neighbor of undirectedByTaskId.get(current) ?? []) {
-            if (visited.has(neighbor)) continue;
-            visited.add(neighbor);
-            stack.push(neighbor);
-          }
-        }
-        for (const taskId of component) {
-          componentSizeByTaskId.set(taskId, component.length);
-        }
-      }
-
-      const fallbackTaskCompare = (left: TTask, right: TTask) => {
-        const leftStart = left.timelineStart ? dayNumber(left.timelineStart) : Number.MAX_SAFE_INTEGER;
-        const rightStart = right.timelineStart ? dayNumber(right.timelineStart) : Number.MAX_SAFE_INTEGER;
-        if (leftStart !== rightStart) return leftStart - rightStart;
-        const leftEnd = left.timelineEnd ? dayNumber(left.timelineEnd) : Number.MAX_SAFE_INTEGER;
-        const rightEnd = right.timelineEnd ? dayNumber(right.timelineEnd) : Number.MAX_SAFE_INTEGER;
-        if (leftEnd !== rightEnd) return leftEnd - rightEnd;
-        return left.id.localeCompare(right.id);
-      };
-
-      const taskById = new Map(lane.tasks.map((task) => [task.id, task] as const));
-      const indegreeByTaskId = new Map<string, number>();
-      const depthByTaskId = new Map<string, number>();
-      for (const task of lane.tasks) {
-        indegreeByTaskId.set(task.id, incomingByTaskId.get(task.id)?.size ?? 0);
-        depthByTaskId.set(task.id, 0);
-      }
-
-      const queue = [...lane.tasks]
-        .filter((task) => (indegreeByTaskId.get(task.id) ?? 0) === 0)
-        .sort(fallbackTaskCompare);
-      while (queue.length) {
-        const current = queue.shift()!;
-        const currentDepth = depthByTaskId.get(current.id) ?? 0;
-        for (const targetTaskId of outgoingByTaskId.get(current.id) ?? []) {
-          depthByTaskId.set(targetTaskId, Math.max(depthByTaskId.get(targetTaskId) ?? 0, currentDepth + 1));
-          const nextInDegree = (indegreeByTaskId.get(targetTaskId) ?? 0) - 1;
-          indegreeByTaskId.set(targetTaskId, nextInDegree);
-          if (nextInDegree === 0) {
-            const nextTask = taskById.get(targetTaskId);
-            if (nextTask) {
-              queue.push(nextTask);
-              queue.sort(fallbackTaskCompare);
-            }
-          }
-        }
-      }
-
-      const tasksForPacking = [...lane.tasks].sort((left, right) => {
-        if (input.dependencyAwarePacking) {
-          const leftComponentSize = componentSizeByTaskId.get(left.id) ?? 1;
-          const rightComponentSize = componentSizeByTaskId.get(right.id) ?? 1;
-          if (leftComponentSize !== rightComponentSize) return rightComponentSize - leftComponentSize;
-          const leftDepth = depthByTaskId.get(left.id) ?? 0;
-          const rightDepth = depthByTaskId.get(right.id) ?? 0;
-          if (leftDepth !== rightDepth) return leftDepth - rightDepth;
-        }
-        return fallbackTaskCompare(left, right);
-      });
-
-      const activeRows: Array<{ rowIndex: number; endDay: number }> = [];
-      const availableRowIndexes: number[] = [];
-      let nextRowIndex = 0;
-
-      for (const task of tasksForPacking) {
-        let rowIndex: number;
-        if (task.hasSchedule && task.inWindow && task.timelineStart && task.timelineEnd) {
-          const taskStartDay = dayNumber(task.timelineStart);
-          const taskEndDay = dayNumber(task.timelineEnd);
-
-          while (activeRows.length && activeRows[0]!.endDay < taskStartDay) {
-            const released = popHeap(activeRows, (left, right) => left.endDay - right.endDay || left.rowIndex - right.rowIndex);
-            if (released) {
-              pushHeap(availableRowIndexes, released.rowIndex, (left, right) => left - right);
-            }
-          }
-
-          rowIndex = popHeap(availableRowIndexes, (left, right) => left - right) ?? nextRowIndex++;
-          pushHeap(activeRows, { rowIndex, endDay: taskEndDay }, (left, right) => left.endDay - right.endDay || left.rowIndex - right.rowIndex);
-        } else {
-          rowIndex = nextRowIndex++;
-        }
-
-        rowIndexByTaskId[task.id] = rowIndex;
-      }
+      Object.assign(
+        rowIndexByTaskId,
+        buildCompactRowPlacement(
+          lane.tasks,
+          input.dependencyAwarePacking,
+          input.dependencyEdges,
+        ).rowIndexByTaskId,
+      );
     }
 
     for (const task of lane.tasks) {
@@ -453,4 +490,37 @@ export function buildTimelineLayout<TTask extends TimelineLayoutTaskInput>(
     bodyHeight: cursorY,
     totalRowCount: input.lanes.length + lanesWithRows.reduce((sum, lane) => sum + lane.rows.length, 0),
   };
+}
+
+export function buildTimelineTaskOrderByLane<TTask extends TimelineLayoutTaskInput>(
+  input: BuildTimelineLayoutInput<TTask>,
+): TimelineTaskOrderByLane {
+  const laneTaskOrder: TimelineTaskOrderByLane = {};
+  const manualRowLaneIds = new Set(input.manualRowLaneIds ?? []);
+  for (const lane of input.lanes) {
+    if (!lane.tasks.length) continue;
+    if (!input.compactRows || manualRowLaneIds.has(lane.id)) {
+      laneTaskOrder[lane.id] = lane.tasks.map((task) => task.id);
+      continue;
+    }
+
+    const compactPlacement = buildCompactRowPlacement(
+      lane.tasks,
+      input.dependencyAwarePacking,
+      input.dependencyEdges,
+    );
+    laneTaskOrder[lane.id] = [...lane.tasks]
+      .sort((left, right) => {
+        const rowDelta =
+          (compactPlacement.rowIndexByTaskId[left.id] ?? 0) -
+          (compactPlacement.rowIndexByTaskId[right.id] ?? 0);
+        if (rowDelta !== 0) return rowDelta;
+        return (
+          (compactPlacement.packingOrderByTaskId.get(left.id) ?? 0) -
+          (compactPlacement.packingOrderByTaskId.get(right.id) ?? 0)
+        );
+      })
+      .map((task) => task.id);
+  }
+  return laneTaskOrder;
 }


### PR DESCRIPTION
## Summary
- replace persistent dependency auto-packing with an explicit Align action that saves manual lane order
- keep manual placement authoritative on rerenders and preserve hidden/off-screen task order when aligning visible lanes
- add focused domain + Playwright coverage for aligned order persistence

## Testing
- pnpm --filter @atlaspm/domain build
- node --test packages/domain/dist/__tests__/timeline-layout.test.js
- pnpm --filter @atlaspm/web-ui type-check
- pnpm e2e e2e/playwright/tests/timeline.spec.ts --grep "timeline align action saves dependency chains ahead of unrelated blockers"

Closes #234