### PR TITLE
Timeline P3-2: extend grouped subtask hierarchy

### DIFF
--- a/apps/web-ui/src/components/project-timeline-view.tsx
+++ b/apps/web-ui/src/components/project-timeline-view.tsx
@@ -111,7 +111,6 @@ type TimelineLaneRail = {
   orderedTasks: TimelineTask[];
   railItems: TimelineRailItem[];
   railItemByTaskId: Map<string, TimelineRailItem>;
-  hasHierarchy: boolean;
   showTaskRail: boolean;
 };
 
@@ -314,6 +313,18 @@ function buildTimelineLaneRail(
   tasks: TimelineTask[],
   childTaskCountByParentId: Map<string, number>,
 ): TimelineLaneRail {
+  const showTaskRail = tasks.some(
+    (task) => Boolean(task.parentId) || (childTaskCountByParentId.get(task.id) ?? 0) > 0,
+  );
+  if (!showTaskRail) {
+    return {
+      orderedTasks: tasks,
+      railItems: [],
+      railItemByTaskId: new Map(),
+      showTaskRail: false,
+    };
+  }
+
   const byId = new Map<string, TimelineRailNode>();
   const orderByTaskId = new Map(tasks.map((task, index) => [task.id, index]));
   for (const task of tasks) {
@@ -368,10 +379,7 @@ function buildTimelineLaneRail(
     orderedTasks: railItems.map((item) => item.task),
     railItems,
     railItemByTaskId: new Map(railItems.map((item) => [item.task.id, item])),
-    hasHierarchy: railItems.some((item) => item.depth > 0),
-    showTaskRail: tasks.some(
-      (task) => Boolean(task.parentId) || (childTaskCountByParentId.get(task.id) ?? 0) > 0,
-    ),
+    showTaskRail: true,
   };
 }
 
@@ -1227,14 +1235,18 @@ export function ProjectScheduleCanvas({
     if (mode !== 'gantt' || ganttRiskFilterMode === 'all') return baseFilteredTasks;
     return baseFilteredTasks.filter((task) => ganttRiskByTaskId.get(task.id)?.isAtRisk);
   }, [baseFilteredTasks, ganttRiskByTaskId, ganttRiskFilterMode, mode]);
+  const scheduledTimelineTasks = useMemo(
+    () => filteredTasks.filter((task) => task.hasSchedule),
+    [filteredTasks],
+  );
   const childTaskCountByParentId = useMemo(() => {
     const next = new Map<string, number>();
-    for (const task of filteredTasks) {
+    for (const task of scheduledTimelineTasks) {
       if (!task.parentId) continue;
       next.set(task.parentId, (next.get(task.parentId) ?? 0) + 1);
     }
     return next;
-  }, [filteredTasks]);
+  }, [scheduledTimelineTasks]);
 
   const preferredLaneOrder = useMemo(() => {
     const storedLaneOrder = readStoredTimelineLaneOrder([
@@ -1277,7 +1289,6 @@ export function ProjectScheduleCanvas({
     : false;
 
   const baseTimelineLanes = useMemo(() => {
-    const scheduledTimelineTasks = filteredTasks.filter((task) => task.hasSchedule);
     const lanes = buildTimelineLanes({
       swimlane: effectiveSwimlane,
       tasks: scheduledTimelineTasks,
@@ -1298,10 +1309,10 @@ export function ProjectScheduleCanvas({
     return lanes;
   }, [
     effectiveSwimlane,
-    filteredTasks,
     hasActiveManualLayout,
     preferredLaneOrder,
     preferredManualLayout,
+    scheduledTimelineTasks,
     t,
     timeline.membersById,
     timeline.sections,

--- a/e2e/playwright/tests/timeline-subtasks-grouped.spec.ts
+++ b/e2e/playwright/tests/timeline-subtasks-grouped.spec.ts
@@ -31,6 +31,18 @@ function dayIso(deltaDays: number) {
   return date.toISOString();
 }
 
+function laneRailTestId(laneTestId: string) {
+  return laneTestId.replace('timeline-lane-', 'timeline-lane-rail-');
+}
+
+async function expectHeaderOnlyRail(page: Page, laneTestId: string, hiddenTaskTitles: string[]) {
+  const laneRail = page.locator(`[data-testid="${laneRailTestId(laneTestId)}"]`);
+  await expect(laneRail).toHaveAttribute('data-header-only', 'true');
+  for (const taskTitle of hiddenTaskTitles) {
+    await expect(laneRail).not.toContainText(taskTitle);
+  }
+}
+
 async function expectNestedRailItem(page: Page, taskId: string, expectedDepth: string) {
   const railItem = page.locator(`[data-testid="timeline-rail-task-${taskId}"]`);
   await expect(railItem).toBeVisible();
@@ -124,4 +136,66 @@ test('timeline grouped swimlanes preserve same-group hierarchy and flatten cross
 
   await expectNestedRailItem(page, sameGroupChild.id, '1');
   await expectFlatRailItem(page, splitGroupChild.id);
+});
+
+test('timeline grouped rails ignore unscheduled subtasks when visible lanes stay flat', async ({
+  page,
+}) => {
+  const now = Date.now();
+  const sub = `e2e-timeline-unscheduled-subtasks-${now}`;
+  const email = `${sub}@example.com`;
+
+  await login(page, sub, email);
+
+  const token = await page.evaluate(() => localStorage.getItem('atlaspm_token') || '');
+  expect(token).toBeTruthy();
+
+  const workspaces = await api('/workspaces', token);
+  const workspaceId = workspaces[0].id as string;
+  const project = await api('/projects', token, 'POST', {
+    workspaceId,
+    name: `Timeline Unscheduled Subtasks ${now}`,
+  });
+  const projectId = project.id as string;
+  const section = await api(`/projects/${projectId}/sections`, token, 'POST', {
+    name: 'Timeline Section',
+  });
+
+  const parentTask = await api(`/projects/${projectId}/tasks`, token, 'POST', {
+    sectionId: section.id,
+    title: `Visible Parent ${now}`,
+    assigneeUserId: sub,
+    startAt: dayIso(0),
+    dueAt: dayIso(3),
+  });
+  const unscheduledChild = await api(`/tasks/${parentTask.id}/subtasks`, token, 'POST', {
+    title: `Hidden Child ${now}`,
+  });
+  await api(`/tasks/${unscheduledChild.id}`, token, 'PATCH', {
+    assigneeUserId: sub,
+    version: unscheduledChild.version,
+  });
+
+  await page.goto(`/projects/${projectId}?view=timeline`);
+  await expect(page.locator('[data-testid="timeline-view"]')).toBeVisible();
+
+  await page.click('[data-testid="timeline-swimlane-assignee"]');
+  await expect(page.locator('[data-testid="timeline-swimlane-assignee"]')).toHaveAttribute(
+    'data-active',
+    'true',
+  );
+  await expectHeaderOnlyRail(page, `timeline-lane-assignee-${sub}`, [
+    parentTask.title,
+    unscheduledChild.title,
+  ]);
+
+  await page.click('[data-testid="timeline-swimlane-status"]');
+  await expect(page.locator('[data-testid="timeline-swimlane-status"]')).toHaveAttribute(
+    'data-active',
+    'true',
+  );
+  await expectHeaderOnlyRail(page, 'timeline-lane-status-IN_PROGRESS', [
+    parentTask.title,
+    unscheduledChild.title,
+  ]);
 });


### PR DESCRIPTION
## Summary
- extend timeline parent-child rail rendering to assignee and status swimlanes when parent/child stay in the same group
- keep grouped cross-lane subtasks visible as flat rail rows instead of reverting the whole lane to header-only
- add a focused Playwright regression for grouped subtask hierarchy and fallback behavior

## Verification
- pnpm type-check:web-ui
- pnpm --filter @atlaspm/web-ui lint
- pnpm e2e:rebuild e2e/playwright/tests/timeline-subtasks-grouped.spec.ts
- pnpm e2e e2e/playwright/tests/timeline-swimlane.spec.ts
- pnpm e2e e2e/playwright/tests/timeline-subtasks-section.spec.ts

Refs #238