### PR TITLE
test: expand grouped free-layout timeline coverage

### DIFF
--- a/apps/core-api/test/core.integration.test.ts
+++ b/apps/core-api/test/core.integration.test.ts
@@ -3166,6 +3166,72 @@ describe('Core API Integration', () => {
       .expect(400);
   });
 
+  test('timeline move preserves edited duration after general date updates', async () => {
+    const workspaceRes = await request(app.getHttpServer())
+      .get('/workspaces')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+    const workspaceId = workspaceRes.body[0].id as string;
+
+    const projectRes = await request(app.getHttpServer())
+      .post('/projects')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ workspaceId, name: 'Timeline Date Consistency Project' })
+      .expect(201);
+    const projectId = projectRes.body.id as string;
+
+    const sectionsRes = await request(app.getHttpServer())
+      .get(`/projects/${projectId}/sections`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+    const defaultSection = sectionsRes.body.find((section: any) => section.isDefault);
+    expect(defaultSection?.id).toBeTruthy();
+
+    const taskRes = await request(app.getHttpServer())
+      .post(`/projects/${projectId}/tasks`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        title: 'Timeline duration source of truth',
+        sectionId: defaultSection.id,
+        startAt: '2026-04-10T00:00:00.000Z',
+        dueAt: '2026-04-12T00:00:00.000Z',
+      })
+      .expect(201);
+    const taskId = taskRes.body.id as string;
+
+    const editedTaskRes = await request(app.getHttpServer())
+      .patch(`/tasks/${taskId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        dueAt: '2026-04-14T00:00:00.000Z',
+        version: taskRes.body.version,
+      })
+      .expect(200);
+
+    expect(editedTaskRes.body.startAt).toContain('2026-04-10');
+    expect(editedTaskRes.body.dueAt).toContain('2026-04-14');
+
+    const movedTaskRes = await request(app.getHttpServer())
+      .patch(`/tasks/${taskId}/timeline-move`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        dropAt: '2026-04-20T00:00:00.000Z',
+        version: editedTaskRes.body.version,
+      })
+      .expect(200);
+
+    expect(movedTaskRes.body.startAt).toContain('2026-04-20');
+    expect(movedTaskRes.body.dueAt).toContain('2026-04-24');
+
+    const detailRes = await request(app.getHttpServer())
+      .get(`/tasks/${taskId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+
+    expect(detailRes.body.startAt).toContain('2026-04-20');
+    expect(detailRes.body.dueAt).toContain('2026-04-24');
+  });
+
   test('timeline reschedule preserves descendant schedules and reports parent move policy', async () => {
     const workspaceRes = await request(app.getHttpServer())
       .get('/workspaces')

--- a/e2e/playwright/tests/timeline-swimlane.spec.ts
+++ b/e2e/playwright/tests/timeline-swimlane.spec.ts
@@ -157,6 +157,29 @@ async function dragTimelineBarVertically(page: Page, taskId: string, deltaY: num
   await page.mouse.up();
 }
 
+async function dragTimelineBarHorizontally(page: Page, taskId: string, deltaDays: number) {
+  const bar = page.locator(`[data-testid="timeline-bar-${taskId}"]`);
+  await expect(bar).toBeVisible();
+  const box = await bar.boundingBox();
+  if (!box) throw new Error(`Unable to resolve bounds for timeline bar ${taskId}`);
+
+  const startX = box.x + Math.min(Math.max(8, box.width / 4), box.width - 4);
+  const startY = box.y + box.height / 2;
+
+  await page.mouse.move(startX, startY);
+  await page.mouse.down();
+  await page.mouse.move(startX + deltaDays * DAY_COLUMN_WIDTH, startY, { steps: 18 });
+  await page.mouse.up();
+}
+
+async function timelineBarBox(page: Page, taskId: string) {
+  const bar = page.locator(`[data-testid="timeline-bar-${taskId}"]`);
+  await expect(bar).toBeVisible();
+  const box = await bar.boundingBox();
+  if (!box) throw new Error(`Unable to resolve bounds for timeline bar ${taskId}`);
+  return box;
+}
+
 function parseTimelineConnectorPath(pathData: string | null) {
   if (!pathData) {
     throw new Error('Expected timeline connector path data');
@@ -853,6 +876,111 @@ test('timeline drag can move task across section and status lanes', async ({ pag
       return latest.status;
     })
     .toBe('IN_PROGRESS');
+});
+
+test('timeline grouped bars stay in sync with drawer date edits after drag reschedule', async ({
+  page,
+}) => {
+  const now = Date.now();
+  const sub = `e2e-timeline-date-sync-${now}`;
+  const email = `${sub}@example.com`;
+
+  await login(page, sub, email);
+  const token = await page.evaluate(() => localStorage.getItem('atlaspm_token') || '');
+  expect(token).toBeTruthy();
+
+  const workspaces = await api('/workspaces', token);
+  const workspaceId = workspaces[0].id as string;
+  const project = await api('/projects', token, 'POST', {
+    workspaceId,
+    name: `Timeline Date Sync ${now}`,
+  });
+  const projectId = project.id as string;
+  const section = await api(`/projects/${projectId}/sections`, token, 'POST', {
+    name: 'Timeline Date Sync Section',
+  });
+
+  const scheduledTask = await api(`/projects/${projectId}/tasks`, token, 'POST', {
+    sectionId: section.id,
+    title: `Date Sync Task ${now}`,
+    assigneeUserId: sub,
+    startAt: dayIso(1),
+    dueAt: dayIso(2),
+  });
+
+  await page.goto(`/projects/${projectId}?view=timeline`);
+  await expect(page.locator('[data-testid="timeline-view"]')).toBeVisible();
+  await page.click('[data-testid="timeline-zoom-day"]');
+  await expect(page.locator('[data-testid="timeline-zoom-day"]')).toHaveAttribute(
+    'data-active',
+    'true',
+  );
+  await page.click('[data-testid="timeline-swimlane-assignee"]');
+  await expect(page.locator('[data-testid="timeline-swimlane-assignee"]')).toHaveAttribute(
+    'data-active',
+    'true',
+  );
+
+  const initialBox = await timelineBarBox(page, scheduledTask.id);
+  await dragTimelineBarHorizontally(page, scheduledTask.id, 1);
+
+  const draggedStartDate = dayIso(2).slice(0, 10);
+  const draggedDueDate = dayIso(3).slice(0, 10);
+  await expect
+    .poll(async () => {
+      const latest = await api(`/tasks/${scheduledTask.id}`, token);
+      return {
+        startAt: String(latest.startAt).slice(0, 10),
+        dueAt: String(latest.dueAt).slice(0, 10),
+      };
+    })
+    .toEqual({
+      startAt: draggedStartDate,
+      dueAt: draggedDueDate,
+    });
+
+  const draggedBox = await timelineBarBox(page, scheduledTask.id);
+  expect(Math.abs((draggedBox.x - initialBox.x) - DAY_COLUMN_WIDTH)).toBeLessThanOrEqual(4);
+
+  await page.click(`[data-testid="timeline-bar-${scheduledTask.id}"]`);
+  await expect(page.locator('[data-testid="task-detail-start-date"]')).toHaveValue(draggedStartDate);
+  await expect(page.locator('[data-testid="task-detail-due-date"]')).toHaveValue(draggedDueDate);
+
+  const extendedDueDate = dayIso(5).slice(0, 10);
+  const dueDateInput = page.locator('[data-testid="task-detail-due-date"]');
+  await dueDateInput.fill(extendedDueDate);
+  await dueDateInput.blur();
+
+  await expect
+    .poll(async () => {
+      const latest = await api(`/tasks/${scheduledTask.id}`, token);
+      return String(latest.dueAt).slice(0, 10);
+    })
+    .toBe(extendedDueDate);
+
+  const extendedBox = await timelineBarBox(page, scheduledTask.id);
+  expect(Math.abs((extendedBox.width - draggedBox.width) - DAY_COLUMN_WIDTH * 2)).toBeLessThanOrEqual(4);
+  await expect(page.locator(`[data-testid="timeline-lane-assignee-${sub}"]`)).toContainText(
+    scheduledTask.title,
+  );
+
+  const widenedStartDate = dayIso(1).slice(0, 10);
+  const startDateInput = page.locator('[data-testid="task-detail-start-date"]');
+  await startDateInput.fill(widenedStartDate);
+  await startDateInput.blur();
+
+  await expect
+    .poll(async () => {
+      const latest = await api(`/tasks/${scheduledTask.id}`, token);
+      return String(latest.startAt).slice(0, 10);
+    })
+    .toBe(widenedStartDate);
+
+  const widenedBox = await timelineBarBox(page, scheduledTask.id);
+  expect(Math.abs((extendedBox.x - widenedBox.x) - DAY_COLUMN_WIDTH)).toBeLessThanOrEqual(4);
+  expect(Math.abs((widenedBox.width - extendedBox.width) - DAY_COLUMN_WIDTH)).toBeLessThanOrEqual(4);
+  await expect(page.locator('[data-testid="task-detail-start-date"]')).toHaveValue(widenedStartDate);
+  await expect(page.locator('[data-testid="task-detail-due-date"]')).toHaveValue(extendedDueDate);
 });
 
 test('timeline can schedule unscheduled tasks via drag and drop', async ({ page }) => {


### PR DESCRIPTION
## Summary
- add core-api coverage for timeline moves using the latest edited task duration
- add grouped timeline Playwright coverage for drag-to-drawer date sync
- verify a focused grouped-timeline regression slice stays green

## Testing
- pnpm --filter @atlaspm/core-api test -- -t "timeline preferences and timeline move APIs persist contracts with audit/outbox|timeline move preserves edited duration after general date updates"
- pnpm --filter @atlaspm/playwright e2e tests/timeline-swimlane.spec.ts tests/timeline-subtasks-grouped.spec.ts -g "timeline manual row layout persists separately for section assignee and status swimlanes|timeline drag can move task across assignee lanes into unassigned|timeline drag can move task across section and status lanes|timeline unscheduled tray drop assigns grouped lane attributes in section assignee and status modes|timeline grouped bars stay in sync with drawer date edits after drag reschedule|timeline grouped swimlanes preserve same-group hierarchy and flatten cross-group subtasks|timeline grouped rails ignore unscheduled subtasks when visible lanes stay flat"

Related to #240