### PR TITLE
Fix legacy timeline manual layout fallback

### DIFF
--- a/apps/core-api/prisma/schema.prisma
+++ b/apps/core-api/prisma/schema.prisma
@@ -186,6 +186,9 @@ model ProjectTimelinePreference {
   userId              String
   laneOrderBySection  String[] @default([])
   laneOrderByAssignee String[] @default([])
+  taskOrderBySection  Json?
+  taskOrderByAssignee Json?
+  taskOrderByStatus   Json?
   timelineManualLayout Json?
   timelineViewState   Json?
   ganttViewState      Json?

--- a/apps/core-api/src/tasks/tasks.controller.ts
+++ b/apps/core-api/src/tasks/tasks.controller.ts
@@ -518,6 +518,12 @@ type TimelineViewMode = (typeof TIMELINE_VIEW_MODE_VALUES)[number];
 type TimelineSwimlane = (typeof TIMELINE_SWIMLANE_VALUES)[number];
 type TimelineManualLayoutByLane = Record<string, string[]>;
 type TimelineManualLayoutState = Record<TimelineSwimlane, TimelineManualLayoutByLane>;
+type TimelineManualLayoutPreferenceRecord = {
+  timelineManualLayout?: Prisma.JsonValue | null;
+  taskOrderBySection?: Prisma.JsonValue | null;
+  taskOrderByAssignee?: Prisma.JsonValue | null;
+  taskOrderByStatus?: Prisma.JsonValue | null;
+};
 type TimelineManualLayoutTaskRecord = Pick<Prisma.TaskGetPayload<{ select: { id: true; sectionId: true; assigneeUserId: true; status: true } }>, 'id' | 'sectionId' | 'assigneeUserId' | 'status'>;
 
 type TaskCustomFieldValueWithRelations = Prisma.TaskCustomFieldValueGetPayload<{
@@ -668,7 +674,7 @@ export class TasksController {
       userId: req.user.sub,
       laneOrderBySection: preferences?.laneOrderBySection ?? [],
       laneOrderByAssignee: preferences?.laneOrderByAssignee ?? [],
-      timelineManualLayout: this.normalizeTimelineManualLayout(preferences?.timelineManualLayout),
+      timelineManualLayout: this.resolveTimelineManualLayout(preferences),
       timelineViewState: preferences?.timelineViewState ?? null,
       ganttViewState: preferences?.ganttViewState ?? null,
     };
@@ -727,7 +733,7 @@ export class TasksController {
         userId: req.user.sub,
         laneOrderBySection: updated.laneOrderBySection,
         laneOrderByAssignee: updated.laneOrderByAssignee,
-        timelineManualLayout: this.normalizeTimelineManualLayout(updated.timelineManualLayout),
+        timelineManualLayout: this.resolveTimelineManualLayout(updated),
         timelineViewState: updated.timelineViewState ?? null,
         ganttViewState: updated.ganttViewState ?? null,
       };
@@ -760,7 +766,7 @@ export class TasksController {
       const before = await tx.projectTimelinePreference.findUnique({
         where: { projectId_userId: { projectId, userId: req.user.sub } },
       });
-      const previousLayout = this.normalizeTimelineManualLayout(before?.timelineManualLayout);
+      const previousLayout = this.resolveTimelineManualLayout(before);
       const nextLayout: TimelineManualLayoutState = {
         ...previousLayout,
         [groupBy]: normalizedGroupLayout,
@@ -800,7 +806,7 @@ export class TasksController {
         userId: req.user.sub,
         laneOrderBySection: updated.laneOrderBySection,
         laneOrderByAssignee: updated.laneOrderByAssignee,
-        timelineManualLayout: this.normalizeTimelineManualLayout(updated.timelineManualLayout),
+        timelineManualLayout: this.resolveTimelineManualLayout(updated),
         timelineViewState: updated.timelineViewState ?? null,
         ganttViewState: updated.ganttViewState ?? null,
       };
@@ -859,7 +865,7 @@ export class TasksController {
         userId: req.user.sub,
         laneOrderBySection: updated.laneOrderBySection,
         laneOrderByAssignee: updated.laneOrderByAssignee,
-        timelineManualLayout: this.normalizeTimelineManualLayout(updated.timelineManualLayout),
+        timelineManualLayout: this.resolveTimelineManualLayout(updated),
         timelineViewState: updated.timelineViewState ?? null,
         ganttViewState: updated.ganttViewState ?? null,
       };
@@ -3192,7 +3198,41 @@ export class TasksController {
     return this.resolveTimelineLaneOrderLimit(tx, projectId, groupBy);
   }
 
-  private normalizeTimelineManualLayout(
+  private resolveTimelineManualLayout(
+    preference: TimelineManualLayoutPreferenceRecord | null | undefined,
+  ): TimelineManualLayoutState {
+    const next = this.normalizeTimelineManualLayoutValue(preference?.timelineManualLayout);
+    if (this.timelineManualLayoutHasEntries(next)) {
+      return next;
+    }
+
+    return {
+      section: this.normalizeStoredTimelineManualLayoutGroup(
+        'section',
+        preference?.taskOrderBySection,
+        Number.MAX_SAFE_INTEGER,
+        Number.MAX_SAFE_INTEGER,
+      ),
+      assignee: this.normalizeStoredTimelineManualLayoutGroup(
+        'assignee',
+        preference?.taskOrderByAssignee,
+        Number.MAX_SAFE_INTEGER,
+        Number.MAX_SAFE_INTEGER,
+      ),
+      status: this.normalizeStoredTimelineManualLayoutGroup(
+        'status',
+        preference?.taskOrderByStatus,
+        Number.MAX_SAFE_INTEGER,
+        Number.MAX_SAFE_INTEGER,
+      ),
+    };
+  }
+
+  private timelineManualLayoutHasEntries(value: TimelineManualLayoutState): boolean {
+    return TIMELINE_SWIMLANE_VALUES.some((groupBy) => Object.keys(value[groupBy]).length > 0);
+  }
+
+  private normalizeTimelineManualLayoutValue(
     value: Prisma.JsonValue | null | undefined,
   ): TimelineManualLayoutState {
     const next = createEmptyTimelineManualLayoutState();
@@ -3200,10 +3240,13 @@ export class TasksController {
       return next;
     }
     const candidate = value as Record<string, unknown>;
+    const hasGroupedShape = TIMELINE_SWIMLANE_VALUES.some((groupBy) =>
+      Object.prototype.hasOwnProperty.call(candidate, groupBy),
+    );
     for (const groupBy of TIMELINE_SWIMLANE_VALUES) {
       next[groupBy] = this.normalizeStoredTimelineManualLayoutGroup(
         groupBy,
-        candidate[groupBy],
+        hasGroupedShape ? candidate[groupBy] : candidate,
         Number.MAX_SAFE_INTEGER,
         Number.MAX_SAFE_INTEGER,
       );

--- a/apps/core-api/test/core.integration.test.ts
+++ b/apps/core-api/test/core.integration.test.ts
@@ -3057,6 +3057,157 @@ describe('Core API Integration', () => {
       .expect(409);
   });
 
+  test('timeline manual layout preserves legacy per-swimlane task order state when upgrading from #232', async () => {
+    const workspaceRes = await request(app.getHttpServer())
+      .get('/workspaces')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+    const workspaceId = workspaceRes.body[0].id as string;
+
+    const projectRes = await request(app.getHttpServer())
+      .post('/projects')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ workspaceId, name: 'Timeline Legacy Manual Layout Project' })
+      .expect(201);
+    const projectId = projectRes.body.id as string;
+
+    const timelineAssigneeId = 'timeline-legacy-member-1';
+    await prisma.user.upsert({
+      where: { id: timelineAssigneeId },
+      create: {
+        id: timelineAssigneeId,
+        email: 'timeline-legacy-member-1@example.com',
+        displayName: 'Timeline Legacy Member 1',
+        status: 'ACTIVE',
+      },
+      update: {},
+    });
+    await prisma.workspaceMembership.upsert({
+      where: { workspaceId_userId: { workspaceId, userId: timelineAssigneeId } },
+      create: { workspaceId, userId: timelineAssigneeId, role: 'WS_MEMBER' },
+      update: {},
+    });
+    await prisma.projectMembership.upsert({
+      where: { projectId_userId: { projectId, userId: timelineAssigneeId } },
+      create: { projectId, userId: timelineAssigneeId, role: 'VIEWER' },
+      update: {},
+    });
+
+    const defaultSection = await prisma.section.findFirstOrThrow({
+      where: { projectId, isDefault: true },
+    });
+    const timelineTaskARes = await request(app.getHttpServer())
+      .post(`/projects/${projectId}/tasks`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        sectionId: defaultSection.id,
+        title: 'Timeline legacy task A',
+        assigneeUserId: timelineAssigneeId,
+        status: 'TODO',
+      })
+      .expect(201);
+    const timelineTaskBRes = await request(app.getHttpServer())
+      .post(`/projects/${projectId}/tasks`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        sectionId: defaultSection.id,
+        title: 'Timeline legacy task B',
+        assigneeUserId: timelineAssigneeId,
+        status: 'TODO',
+      })
+      .expect(201);
+    const timelineTaskCRes = await request(app.getHttpServer())
+      .post(`/projects/${projectId}/tasks`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        sectionId: defaultSection.id,
+        title: 'Timeline legacy task C',
+        assigneeUserId: timelineAssigneeId,
+        status: 'TODO',
+      })
+      .expect(201);
+
+    const legacySectionLayout = {
+      [`section:${defaultSection.id}`]: [timelineTaskCRes.body.id, timelineTaskARes.body.id],
+    };
+    const legacyAssigneeLayout = {
+      [`assignee:${timelineAssigneeId}`]: [timelineTaskBRes.body.id, timelineTaskARes.body.id],
+    };
+    const legacyStatusLaneId = `status:${timelineTaskARes.body.status as string}`;
+
+    await prisma.projectTimelinePreference.create({
+      data: {
+        projectId,
+        userId: 'test-user',
+        laneOrderBySection: [],
+        laneOrderByAssignee: [],
+      },
+    });
+    await prisma.$executeRawUnsafe(
+      `
+        UPDATE "ProjectTimelinePreference"
+        SET "taskOrderBySection" = $1::jsonb,
+            "taskOrderByAssignee" = $2::jsonb
+        WHERE "projectId" = $3 AND "userId" = $4
+      `,
+      JSON.stringify(legacySectionLayout),
+      JSON.stringify(legacyAssigneeLayout),
+      projectId,
+      'test-user',
+    );
+
+    const legacyPrefsRes = await request(app.getHttpServer())
+      .get(`/projects/${projectId}/timeline/preferences`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+    expect(legacyPrefsRes.body.timelineManualLayout).toEqual({
+      section: legacySectionLayout,
+      assignee: legacyAssigneeLayout,
+      status: {},
+    });
+
+    const statusManualLayoutRes = await request(app.getHttpServer())
+      .put(`/projects/${projectId}/timeline/preferences/manual-layout/status`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        laneTaskOrder: {
+          [legacyStatusLaneId]: [
+            timelineTaskARes.body.id,
+            timelineTaskBRes.body.id,
+            timelineTaskCRes.body.id,
+          ],
+        },
+      })
+      .expect(200);
+    expect(statusManualLayoutRes.body.timelineManualLayout).toEqual({
+      section: legacySectionLayout,
+      assignee: legacyAssigneeLayout,
+      status: {
+        [legacyStatusLaneId]: [
+          timelineTaskARes.body.id,
+          timelineTaskBRes.body.id,
+          timelineTaskCRes.body.id,
+        ],
+      },
+    });
+
+    const persistedPrefsRes = await request(app.getHttpServer())
+      .get(`/projects/${projectId}/timeline/preferences`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+    expect(persistedPrefsRes.body.timelineManualLayout).toEqual({
+      section: legacySectionLayout,
+      assignee: legacyAssigneeLayout,
+      status: {
+        [legacyStatusLaneId]: [
+          timelineTaskARes.body.id,
+          timelineTaskBRes.body.id,
+          timelineTaskCRes.body.id,
+        ],
+      },
+    });
+  });
+
   test('timeline move supports section, status, and custom field lane reassignment', async () => {
     const workspaceRes = await request(app.getHttpServer())
       .get('/workspaces')


### PR DESCRIPTION
## Summary
- preserve legacy #232 timeline task-order data as manual layout fallback when reading preferences
- merge that legacy per-swimlane state into the new `timelineManualLayout` payload on the next manual-layout save
- add a focused integration test covering upgrade from the old `taskOrderBy*` columns

## Testing
- pnpm --filter @atlaspm/core-api test -- test/core.integration.test.ts
- pnpm --filter @atlaspm/domain test -- --test-name-pattern "timeline"
- pnpm --filter @atlaspm/playwright exec playwright test tests/timeline-swimlane.spec.ts -g "timeline manual row layout persists separately for section assignee and status swimlanes"