### PR TITLE
fix(api): normalize task date-only scheduling

### DIFF
--- a/apps/core-api/prisma/migrations/20260308143000_normalize_task_date_only_schedule/migration.sql
+++ b/apps/core-api/prisma/migrations/20260308143000_normalize_task_date_only_schedule/migration.sql
@@ -1,0 +1,29 @@
+UPDATE "Task"
+SET
+  "startAt" = CASE
+    WHEN "startAt" IS NULL THEN NULL
+    ELSE date_trunc('day', "startAt")
+  END,
+  "dueAt" = CASE
+    WHEN "dueAt" IS NULL THEN NULL
+    ELSE date_trunc('day', "dueAt")
+  END,
+  "baselineStartAt" = CASE
+    WHEN "baselineStartAt" IS NULL THEN NULL
+    ELSE date_trunc('day', "baselineStartAt")
+  END,
+  "baselineDueAt" = CASE
+    WHEN "baselineDueAt" IS NULL THEN NULL
+    ELSE date_trunc('day', "baselineDueAt")
+  END
+WHERE
+  ("startAt" IS NOT NULL AND "startAt" <> date_trunc('day', "startAt"))
+  OR ("dueAt" IS NOT NULL AND "dueAt" <> date_trunc('day', "dueAt"))
+  OR (
+    "baselineStartAt" IS NOT NULL
+    AND "baselineStartAt" <> date_trunc('day', "baselineStartAt")
+  )
+  OR (
+    "baselineDueAt" IS NOT NULL
+    AND "baselineDueAt" <> date_trunc('day', "baselineDueAt")
+  );

--- a/apps/core-api/src/common/date-validation.ts
+++ b/apps/core-api/src/common/date-validation.ts
@@ -1,5 +1,7 @@
 import { BadRequestException } from '@nestjs/common';
 
+const ISO_DATE_PREFIX_PATTERN = /^(\d{4})-(\d{2})-(\d{2})(?:$|T)/;
+
 export interface DateRangeValidationResult {
   valid: boolean;
   error?: {
@@ -13,6 +15,60 @@ export interface DateRangeFieldNames {
   dueField: string;
 }
 
+function normalizeDateOnlyIsoStringInternal(value: string): string | null {
+  const trimmed = value.trim();
+  const match = ISO_DATE_PREFIX_PATTERN.exec(trimmed);
+  if (!match) return null;
+
+  const year = Number(match[1]);
+  const monthIndex = Number(match[2]) - 1;
+  const day = Number(match[3]);
+  const parsed = new Date(trimmed);
+  if (Number.isNaN(parsed.getTime())) return null;
+
+  const normalized = new Date(Date.UTC(year, monthIndex, day, 0, 0, 0, 0));
+  if (
+    normalized.getUTCFullYear() !== year ||
+    normalized.getUTCMonth() !== monthIndex ||
+    normalized.getUTCDate() !== day
+  ) {
+    return null;
+  }
+
+  return normalized.toISOString();
+}
+
+export function normalizeDateOnlyIsoString(value: string): string {
+  const normalized = normalizeDateOnlyIsoStringInternal(value);
+  if (!normalized) {
+    throw new BadRequestException({
+      code: 'INVALID_DATE_FORMAT',
+      message: 'Date must be a valid ISO8601 date string',
+    });
+  }
+  return normalized;
+}
+
+export function normalizeOptionalDateOnlyIsoString(
+  value: string | null | undefined,
+): string | null | undefined {
+  if (value === null || value === undefined) return value;
+  return normalizeDateOnlyIsoString(value);
+}
+
+export function normalizeStoredDateOnly(value: Date | null | undefined): Date | null | undefined {
+  if (value === null || value === undefined) return value;
+  return new Date(Date.UTC(value.getUTCFullYear(), value.getUTCMonth(), value.getUTCDate(), 0, 0, 0, 0));
+}
+
+export function parseOptionalDateOnlyIsoString(
+  value: string | null | undefined,
+): Date | null | undefined {
+  const normalized = normalizeOptionalDateOnlyIsoString(value);
+  if (normalized === null || normalized === undefined) return normalized;
+  return new Date(normalized);
+}
+
 export function validateDateRange(
   startAt: string | null | undefined,
   dueAt: string | null | undefined,
@@ -22,10 +78,10 @@ export function validateDateRange(
     return { valid: true };
   }
 
-  const start = new Date(startAt);
-  const due = new Date(dueAt);
+  const normalizedStartAt = normalizeDateOnlyIsoStringInternal(startAt);
+  const normalizedDueAt = normalizeDateOnlyIsoStringInternal(dueAt);
 
-  if (isNaN(start.getTime())) {
+  if (!normalizedStartAt) {
     return {
       valid: false,
       error: {
@@ -35,7 +91,7 @@ export function validateDateRange(
     };
   }
 
-  if (isNaN(due.getTime())) {
+  if (!normalizedDueAt) {
     return {
       valid: false,
       error: {
@@ -45,6 +101,8 @@ export function validateDateRange(
     };
   }
 
+  const start = new Date(normalizedStartAt);
+  const due = new Date(normalizedDueAt);
   if (start.getTime() > due.getTime()) {
     return {
       valid: false,

--- a/apps/core-api/src/tasks/tasks.controller.ts
+++ b/apps/core-api/src/tasks/tasks.controller.ts
@@ -39,7 +39,12 @@ import { PrismaService } from '../prisma/prisma.service';
 import { DomainService } from '../common/domain.service';
 import { CurrentRequest } from '../common/current-request';
 import type { AppRequest } from '../common/types';
-import { assertValidDateRange } from '../common/date-validation';
+import {
+  assertValidDateRange,
+  normalizeOptionalDateOnlyIsoString,
+  normalizeStoredDateOnly,
+  parseOptionalDateOnlyIsoString,
+} from '../common/date-validation';
 import { Prisma, Priority, ProjectRole, TaskStatus, TaskType, DependencyType, CustomFieldType } from '@prisma/client';
 import { completeTaskLifecycle, DomainConflictError, DomainNotFoundError } from '@atlaspm/domain';
 import { SubtaskService } from './subtask.service';
@@ -893,6 +898,10 @@ export class TasksController {
       startField: 'baselineStartAt',
       dueField: 'baselineDueAt',
     });
+    const normalizedStartAt = parseOptionalDateOnlyIsoString(body.startAt);
+    const normalizedDueAt = parseOptionalDateOnlyIsoString(body.dueAt);
+    const normalizedBaselineStartAt = parseOptionalDateOnlyIsoString(body.baselineStartAt);
+    const normalizedBaselineDueAt = parseOptionalDateOnlyIsoString(body.baselineDueAt);
 
     let sectionId = body.sectionId;
     if (!sectionId) {
@@ -932,10 +941,10 @@ export class TasksController {
           progressPercent: progress,
           priority: body.priority,
           assigneeUserId: body.assigneeUserId,
-          startAt: body.startAt ? new Date(body.startAt) : null,
-          dueAt: body.dueAt ? new Date(body.dueAt) : null,
-          baselineStartAt: body.baselineStartAt ? new Date(body.baselineStartAt) : null,
-          baselineDueAt: body.baselineDueAt ? new Date(body.baselineDueAt) : null,
+          startAt: normalizedStartAt ?? null,
+          dueAt: normalizedDueAt ?? null,
+          baselineStartAt: normalizedBaselineStartAt ?? null,
+          baselineDueAt: normalizedBaselineDueAt ?? null,
           tags: body.tags ?? [],
           completedAt,
           position,
@@ -953,7 +962,7 @@ export class TasksController {
         payload: task,
       });
       await this.applyProgressRules(tx, task.id, req.correlationId);
-      return task;
+      return this.normalizeTaskDateFields(task);
     }).then((task) => {
       void this.indexTaskWithCustomFields(task);
       return task;
@@ -981,6 +990,10 @@ export class TasksController {
       startField: 'baselineStartAt',
       dueField: 'baselineDueAt',
     });
+    const normalizedBodyStartAt = normalizeOptionalDateOnlyIsoString(body.startAt);
+    const normalizedBodyDueAt = normalizeOptionalDateOnlyIsoString(body.dueAt);
+    const normalizedBodyBaselineStartAt = normalizeOptionalDateOnlyIsoString(body.baselineStartAt);
+    const normalizedBodyBaselineDueAt = normalizeOptionalDateOnlyIsoString(body.baselineDueAt);
 
     const newType = body.type ?? task.type;
     const requestedStatus = body.status ?? task.status;
@@ -1012,26 +1025,29 @@ export class TasksController {
           progressPercent: progress,
           priority: body.priority,
           assigneeUserId: body.assigneeUserId,
-          startAt: body.startAt ? new Date(body.startAt) : body.startAt === null ? null : undefined,
-          dueAt: body.dueAt ? new Date(body.dueAt) : body.dueAt === null ? null : undefined,
+          startAt:
+            normalizedBodyStartAt !== undefined
+              ? parseOptionalDateOnlyIsoString(normalizedBodyStartAt)
+              : undefined,
+          dueAt:
+            normalizedBodyDueAt !== undefined
+              ? parseOptionalDateOnlyIsoString(normalizedBodyDueAt)
+              : undefined,
           baselineStartAt:
-            body.baselineStartAt
-              ? new Date(body.baselineStartAt)
-              : body.baselineStartAt === null
-                ? null
-                : undefined,
+            normalizedBodyBaselineStartAt !== undefined
+              ? parseOptionalDateOnlyIsoString(normalizedBodyBaselineStartAt)
+              : undefined,
           baselineDueAt:
-            body.baselineDueAt
-              ? new Date(body.baselineDueAt)
-              : body.baselineDueAt === null
-                ? null
-                : undefined,
+            normalizedBodyBaselineDueAt !== undefined
+              ? parseOptionalDateOnlyIsoString(normalizedBodyBaselineDueAt)
+              : undefined,
           tags: body.tags,
           sectionId: body.sectionId,
           completedAt,
           version: { increment: 1 },
         },
       });
+      const normalizedUpdated = this.normalizeTaskDateFields(updated);
       await this.domain.appendAuditOutbox({
         tx,
         actor: req.user.sub,
@@ -1039,10 +1055,10 @@ export class TasksController {
         entityId: id,
         action: 'task.updated',
         beforeJson: task,
-        afterJson: updated,
+        afterJson: normalizedUpdated,
         correlationId: req.correlationId,
         outboxType: 'task.updated',
-        payload: updated,
+        payload: normalizedUpdated,
       });
       await this.applyProgressRules(tx, id, req.correlationId);
 
@@ -1065,9 +1081,8 @@ export class TasksController {
         if (body.dueAt === null) {
           dueDateChanged = task.dueAt !== null;
         } else {
-          const newDueDate = new Date(body.dueAt).getTime();
-          const oldDueDate = task.dueAt ? task.dueAt.getTime() : null;
-          dueDateChanged = newDueDate !== oldDueDate;
+          const oldDueDate = task.dueAt ? task.dueAt.toISOString() : null;
+          dueDateChanged = normalizedBodyDueAt !== oldDueDate;
         }
       }
       if (dueDateChanged && postUpdateAssigneeId) {
@@ -1094,7 +1109,7 @@ export class TasksController {
         });
       }
 
-      return updated;
+      return normalizedUpdated;
     }).then((updated) => {
       void this.indexTaskWithCustomFields(updated);
       return updated;
@@ -1122,13 +1137,21 @@ export class TasksController {
     const effectiveStartAt = body.startAt === undefined ? task.startAt?.toISOString() : body.startAt;
     const effectiveDueAt = body.dueAt === undefined ? task.dueAt?.toISOString() : body.dueAt;
     assertValidDateRange(effectiveStartAt, effectiveDueAt);
+    const normalizedBodyStartAt = normalizeOptionalDateOnlyIsoString(body.startAt);
+    const normalizedBodyDueAt = normalizeOptionalDateOnlyIsoString(body.dueAt);
 
     return this.prisma.$transaction(async (tx) => {
       const updatedRows = await tx.task.updateMany({
         where: { id, deletedAt: null, version: body.version },
         data: {
-          startAt: body.startAt ? new Date(body.startAt) : body.startAt === null ? null : undefined,
-          dueAt: body.dueAt ? new Date(body.dueAt) : body.dueAt === null ? null : undefined,
+          startAt:
+            normalizedBodyStartAt !== undefined
+              ? parseOptionalDateOnlyIsoString(normalizedBodyStartAt)
+              : undefined,
+          dueAt:
+            normalizedBodyDueAt !== undefined
+              ? parseOptionalDateOnlyIsoString(normalizedBodyDueAt)
+              : undefined,
           version: { increment: 1 },
         },
       });
@@ -1145,7 +1168,9 @@ export class TasksController {
         });
       }
 
-      const updated = await tx.task.findFirstOrThrow({ where: { id, deletedAt: null } });
+      const updated = this.normalizeTaskDateFields(
+        await tx.task.findFirstOrThrow({ where: { id, deletedAt: null } }),
+      );
       const subtaskMovePolicy = await this.buildTimelineSubtaskMovePolicy(tx, id);
       await this.domain.appendAuditOutbox({
         tx,
@@ -1264,6 +1289,14 @@ export class TasksController {
       });
     }
 
+    if (!hasDrop) {
+      const effectiveStartAt = body.startAt === undefined ? task.startAt?.toISOString() : body.startAt;
+      const effectiveDueAt = body.dueAt === undefined ? task.dueAt?.toISOString() : body.dueAt;
+      assertValidDateRange(effectiveStartAt, effectiveDueAt);
+    }
+
+    const normalizedBodyStartAt = normalizeOptionalDateOnlyIsoString(body.startAt);
+    const normalizedBodyDueAt = normalizeOptionalDateOnlyIsoString(body.dueAt);
     let nextStartAt: Date | null = task.startAt;
     let nextDueAt: Date | null = task.dueAt;
     if (hasDrop) {
@@ -1276,11 +1309,11 @@ export class TasksController {
       nextStartAt = dropSchedule.startAt;
       nextDueAt = dropSchedule.dueAt;
     } else {
-      if (body.startAt !== undefined) {
-        nextStartAt = body.startAt ? new Date(body.startAt) : null;
+      if (normalizedBodyStartAt !== undefined) {
+        nextStartAt = parseOptionalDateOnlyIsoString(normalizedBodyStartAt) ?? null;
       }
-      if (body.dueAt !== undefined) {
-        nextDueAt = body.dueAt ? new Date(body.dueAt) : null;
+      if (normalizedBodyDueAt !== undefined) {
+        nextDueAt = parseOptionalDateOnlyIsoString(normalizedBodyDueAt) ?? null;
       }
     }
     this.domain.assertTimelineScheduleRange(nextStartAt, nextDueAt);
@@ -1426,7 +1459,9 @@ export class TasksController {
         }
       }
 
-      const updated = await tx.task.findFirstOrThrow({ where: { id, deletedAt: null } });
+      const updated = this.normalizeTaskDateFields(
+        await tx.task.findFirstOrThrow({ where: { id, deletedAt: null } }),
+      );
       const subtaskMovePolicy = await this.buildTimelineSubtaskMovePolicy(tx, id);
       let serializedCurrentCustomFieldValues: SerializedTaskCustomFieldValue[] | undefined;
       if (parsedCustomFieldMove) {
@@ -2522,6 +2557,8 @@ export class TasksController {
       throw new BadRequestException('Nested subtasks are not supported');
     }
     assertValidDateRange(body.startAt, body.dueAt);
+    const normalizedStartAt = parseOptionalDateOnlyIsoString(body.startAt);
+    const normalizedDueAt = parseOptionalDateOnlyIsoString(body.dueAt);
 
     const topTask = await this.prisma.task.findFirst({
       where: { projectId: parentTask.projectId, sectionId: parentTask.sectionId, deletedAt: null },
@@ -2534,31 +2571,40 @@ export class TasksController {
       projectId: parentTask.projectId,
       sectionId: parentTask.sectionId,
       position,
-      startAt: body.startAt ? new Date(body.startAt) : null,
-      dueAt: body.dueAt ? new Date(body.dueAt) : null,
+      startAt: normalizedStartAt ?? null,
+      dueAt: normalizedDueAt ?? null,
     };
-    return this.subtaskService.createSubtask(parentId, taskData);
+    return this.normalizeTaskDateFields(await this.subtaskService.createSubtask(parentId, taskData));
   }
 
   @Get('tasks/:id/subtasks')
   async getSubtasks(@Param('id') taskId: string, @CurrentRequest() req: AppRequest) {
     const task = await this.prisma.task.findFirstOrThrow({ where: { id: taskId, deletedAt: null } });
     await this.domain.requireProjectRole(task.projectId, req.user.sub, ProjectRole.VIEWER);
-    return this.subtaskService.getSubtasks(taskId);
+    return (await this.subtaskService.getSubtasks(taskId)).map((subtask) =>
+      this.normalizeTaskDateFields(subtask),
+    );
   }
 
   @Get('tasks/:id/subtasks/tree')
   async getSubtaskTree(@Param('id') taskId: string, @CurrentRequest() req: AppRequest) {
     const task = await this.prisma.task.findFirstOrThrow({ where: { id: taskId, deletedAt: null } });
     await this.domain.requireProjectRole(task.projectId, req.user.sub, ProjectRole.VIEWER);
-    return this.subtaskService.getSubtaskTree(taskId);
+    const normalizeTree = (nodes: Awaited<ReturnType<SubtaskService['getSubtaskTree']>>): typeof nodes =>
+      nodes.map((node) => ({
+        ...this.normalizeTaskDateFields(node),
+        children: normalizeTree(node.children),
+      }));
+    return normalizeTree(await this.subtaskService.getSubtaskTree(taskId));
   }
 
   @Get('tasks/:id/breadcrumbs')
   async getBreadcrumbs(@Param('id') taskId: string, @CurrentRequest() req: AppRequest) {
     const task = await this.prisma.task.findFirstOrThrow({ where: { id: taskId, deletedAt: null } });
     await this.domain.requireProjectRole(task.projectId, req.user.sub, ProjectRole.VIEWER);
-    return this.subtaskService.getBreadcrumbPath(taskId);
+    return (await this.subtaskService.getBreadcrumbPath(taskId)).map((breadcrumb) =>
+      this.normalizeTaskDateFields(breadcrumb),
+    );
   }
 
   // Dependency endpoints
@@ -2698,7 +2744,12 @@ export class TasksController {
   private async hydrateTasksWithCustomFieldValues(
     tasks: Array<Record<string, unknown> & { id: string }>,
   ): Promise<Array<Record<string, unknown> & { id: string; customFieldValues: SerializedTaskCustomFieldValue[] }>> {
-    if (!tasks.length) return tasks.map((task) => ({ ...task, customFieldValues: [] }));
+    if (!tasks.length) {
+      return tasks.map((task) => ({
+        ...this.normalizeTaskDateFields(task),
+        customFieldValues: [],
+      }));
+    }
     const taskIds = tasks.map((task) => task.id);
     const values = await this.prisma.taskCustomFieldValue.findMany({
       where: {
@@ -2730,9 +2781,25 @@ export class TasksController {
       });
     }
     return tasks.map((task) => ({
-      ...task,
+      ...this.normalizeTaskDateFields(task),
       customFieldValues: byTaskId.get(task.id) ?? [],
     }));
+  }
+
+  private normalizeTaskDateFields<T extends object>(task: T): T {
+    const candidate = task as {
+      startAt?: Date | null;
+      dueAt?: Date | null;
+      baselineStartAt?: Date | null;
+      baselineDueAt?: Date | null;
+    };
+    return {
+      ...task,
+      startAt: normalizeStoredDateOnly(candidate.startAt),
+      dueAt: normalizeStoredDateOnly(candidate.dueAt),
+      baselineStartAt: normalizeStoredDateOnly(candidate.baselineStartAt),
+      baselineDueAt: normalizeStoredDateOnly(candidate.baselineDueAt),
+    };
   }
 
   private serializeTaskCustomFieldValue(value: TaskCustomFieldValueWithRelations): SerializedTaskCustomFieldValue {

--- a/apps/core-api/test/core.integration.test.ts
+++ b/apps/core-api/test/core.integration.test.ts
@@ -2090,6 +2090,39 @@ describe('Core API Integration', () => {
     expect((dateCreateOutbox?.payload as any)?.dueAt).toBeTruthy();
   });
 
+  test('POST /projects/:id/tasks normalizes offset datetime payloads to UTC date-only values', async () => {
+    const wsRes = await request(app.getHttpServer()).get('/workspaces').set('Authorization', `Bearer ${token}`).expect(200);
+    const workspaceId = wsRes.body[0].id;
+
+    const projectRes = await request(app.getHttpServer())
+      .post('/projects')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ workspaceId, name: `Date Only Normalization ${Date.now()}` })
+      .expect(201);
+    const projectId = projectRes.body.id as string;
+
+    const createRes = await request(app.getHttpServer())
+      .post(`/projects/${projectId}/tasks`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        title: 'Task with offset datetime payload',
+        startAt: '2026-03-10T00:00:00+14:00',
+        dueAt: '2026-03-12T00:00:00+14:00',
+      })
+      .expect(201);
+
+    expect(createRes.body.startAt).toBe('2026-03-10T00:00:00.000Z');
+    expect(createRes.body.dueAt).toBe('2026-03-12T00:00:00.000Z');
+
+    const detailRes = await request(app.getHttpServer())
+      .get(`/tasks/${createRes.body.id}`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+
+    expect(detailRes.body.startAt).toBe('2026-03-10T00:00:00.000Z');
+    expect(detailRes.body.dueAt).toBe('2026-03-12T00:00:00.000Z');
+  });
+
   test('POST /projects/:id/tasks accepts open-ended date ranges', async () => {
     const wsRes = await request(app.getHttpServer()).get('/workspaces').set('Authorization', `Bearer ${token}`).expect(200);
     const workspaceId = wsRes.body[0].id;
@@ -2279,6 +2312,49 @@ describe('Core API Integration', () => {
     expect(rescheduleOutbox).toBeTruthy();
     expect((rescheduleOutbox?.payload as any)?.projectId).toBe(projectId);
     expect((rescheduleOutbox?.payload as any)?.dueAt).toBeTruthy();
+  });
+
+  test('PATCH /tasks/:id/reschedule normalizes offset datetime payloads to UTC date-only values', async () => {
+    const wsRes = await request(app.getHttpServer()).get('/workspaces').set('Authorization', `Bearer ${token}`).expect(200);
+    const workspaceId = wsRes.body[0].id;
+
+    const projectRes = await request(app.getHttpServer())
+      .post('/projects')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ workspaceId, name: `Reschedule Date Only ${Date.now()}` })
+      .expect(201);
+    const projectId = projectRes.body.id as string;
+
+    const taskRes = await request(app.getHttpServer())
+      .post(`/projects/${projectId}/tasks`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        title: 'Task to normalize on reschedule',
+        startAt: '2026-03-10T00:00:00.000Z',
+        dueAt: '2026-03-12T00:00:00.000Z',
+      })
+      .expect(201);
+
+    const rescheduleRes = await request(app.getHttpServer())
+      .patch(`/tasks/${taskRes.body.id}/reschedule`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        startAt: '2026-03-14T00:00:00+14:00',
+        dueAt: '2026-03-16T00:00:00+14:00',
+        version: taskRes.body.version,
+      })
+      .expect(200);
+
+    expect(rescheduleRes.body.startAt).toBe('2026-03-14T00:00:00.000Z');
+    expect(rescheduleRes.body.dueAt).toBe('2026-03-16T00:00:00.000Z');
+
+    const detailRes = await request(app.getHttpServer())
+      .get(`/tasks/${taskRes.body.id}`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+
+    expect(detailRes.body.startAt).toBe('2026-03-14T00:00:00.000Z');
+    expect(detailRes.body.dueAt).toBe('2026-03-16T00:00:00.000Z');
   });
 
   test('PATCH /tasks/:id/reschedule returns 409 with latest server truth on version conflict', async () => {


### PR DESCRIPTION
## Summary
- normalize task schedule write paths to canonical UTC-midnight date-only values
- normalize task read paths for legacy mixed timestamps and add a DB migration for existing rows
- add focused API regression coverage for offset datetime create/reschedule payloads

## Testing
- pnpm --filter @atlaspm/core-api type-check
- pnpm --filter @atlaspm/core-api test -- -t "POST /projects/:id/tasks rejects invalid date range|POST /projects/:id/tasks normalizes offset datetime payloads to UTC date-only values|PATCH /tasks/:id rejects invalid date range update|PATCH /tasks/:id/reschedule updates dates with optimistic locking and emits audit/outbox|PATCH /tasks/:id/reschedule normalizes offset datetime payloads to UTC date-only values|timeline move preserves edited duration after general date updates"

Closes #266