### PR TITLE
test: add stable timeline gantt root-cause fixtures

### DIFF
--- a/e2e/playwright/tests/helpers/timeline-root-cause-fixtures.ts
+++ b/e2e/playwright/tests/helpers/timeline-root-cause-fixtures.ts
@@ -1,0 +1,318 @@
+import type { Page } from '@playwright/test';
+
+const API = process.env.E2E_CORE_API_URL ?? 'http://localhost:3001';
+
+type Workspace = {
+  id: string;
+};
+
+type Project = {
+  id: string;
+};
+
+type Section = {
+  id: string;
+  isDefault?: boolean;
+};
+
+type Task = {
+  id: string;
+  title: string;
+  startAt: string | null;
+  dueAt: string | null;
+  version: number;
+  sectionId: string | null;
+};
+
+export type TimelineFixtureSession = {
+  token: string;
+  userId: string;
+  email: string;
+  workspaceId: string;
+  dayIso: (offsetDays: number) => string;
+  lateUtcIso: (offsetDays: number) => string;
+  dateOnlyLabel: (value: string) => string;
+};
+
+export type ManualPlacementFixture = {
+  projectId: string;
+  sectionId: string;
+  longTask: Task;
+  earlyTask: Task;
+  lateTask: Task;
+};
+
+export type ResizeFixture = {
+  projectId: string;
+  task: Task;
+  startAt: string;
+  dueAt: string;
+  resizedDueAt: string;
+};
+
+export type DatePersistenceFixture = {
+  projectId: string;
+  task: Task;
+  nextStartDate: string;
+  nextDueDate: string;
+};
+
+export type GroupedSubtasksFixture = {
+  projectId: string;
+  sectionAId: string;
+  sectionBId: string;
+  parent: Task;
+  child: Task;
+};
+
+export type ViewTransitionFixture = {
+  projectId: string;
+  defaultSectionId: string;
+  earlierTask: Task;
+  laterTask: Task;
+};
+
+async function api<T>(path: string, token: string, method = 'GET', body?: unknown): Promise<T> {
+  const res = await fetch(`${API}${path}`, {
+    method,
+    headers: {
+      'content-type': 'application/json',
+      authorization: `Bearer ${token}`,
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  if (!res.ok) throw new Error(`API ${res.status}: ${await res.text()}`);
+  const raw = await res.text();
+  return raw ? (JSON.parse(raw) as T) : (null as T);
+}
+
+export async function loginDevUser(page: Page, sub: string, email: string) {
+  await page.goto('/login');
+  await page.fill('input[placeholder="OIDC sub"]', sub);
+  await page.fill('input[placeholder="Email"]', email);
+  await page.click('button:has-text("Dev Login")');
+  await page.waitForURL('**/');
+}
+
+function buildDayFactory(anchor: Date, hour: number) {
+  return (offsetDays: number) => {
+    const next = new Date(anchor);
+    next.setUTCHours(hour, 0, 0, 0);
+    next.setUTCDate(next.getUTCDate() + offsetDays);
+    return next.toISOString();
+  };
+}
+
+function dateOnlyLabel(value: string) {
+  const [year, month, day] = value.slice(0, 10).split('-').map(Number);
+  return new Date(year, month - 1, day).toLocaleDateString('en-US');
+}
+
+async function createProject(session: TimelineFixtureSession, name: string) {
+  return api<Project>('/projects', session.token, 'POST', {
+    workspaceId: session.workspaceId,
+    name,
+  });
+}
+
+async function createSection(session: TimelineFixtureSession, projectId: string, name: string) {
+  return api<Section>(`/projects/${projectId}/sections`, session.token, 'POST', { name });
+}
+
+async function listSections(session: TimelineFixtureSession, projectId: string) {
+  return api<Section[]>(`/projects/${projectId}/sections`, session.token);
+}
+
+async function createTask(
+  session: TimelineFixtureSession,
+  projectId: string,
+  body: Record<string, unknown>,
+) {
+  return api<Task>(`/projects/${projectId}/tasks`, session.token, 'POST', body);
+}
+
+async function createSubtask(session: TimelineFixtureSession, parentTaskId: string, body: Record<string, unknown>) {
+  return api<Task>(`/tasks/${parentTaskId}/subtasks`, session.token, 'POST', body);
+}
+
+async function createDependency(
+  session: TimelineFixtureSession,
+  taskId: string,
+  dependsOnId: string,
+) {
+  await api(`/tasks/${taskId}/dependencies`, session.token, 'POST', {
+    dependsOnId,
+    type: 'BLOCKS',
+  });
+}
+
+export async function createTimelineFixtureSession(
+  page: Page,
+  prefix: string,
+): Promise<TimelineFixtureSession> {
+  const userId = `${prefix}-${Date.now()}`;
+  const email = `${userId}@example.com`;
+
+  await loginDevUser(page, userId, email);
+  const token = await page.evaluate(() => localStorage.getItem('atlaspm_token') || '');
+  if (!token) {
+    throw new Error('Expected atlaspm_token after dev login');
+  }
+
+  const workspaces = await api<Workspace[]>('/workspaces', token);
+  const workspaceId = workspaces[0]?.id;
+  if (!workspaceId) {
+    throw new Error('Expected at least one workspace for dev login');
+  }
+
+  const anchor = new Date();
+  anchor.setUTCHours(0, 0, 0, 0);
+
+  return {
+    token,
+    userId,
+    email,
+    workspaceId,
+    dayIso: buildDayFactory(anchor, 0),
+    lateUtcIso: buildDayFactory(anchor, 23),
+    dateOnlyLabel,
+  };
+}
+
+export async function seedManualPlacementFixture(
+  session: TimelineFixtureSession,
+): Promise<ManualPlacementFixture> {
+  const project = await createProject(session, 'Timeline Manual Placement Fixture');
+  const section = await createSection(session, project.id, 'Manual Section');
+  const longTask = await createTask(session, project.id, {
+    sectionId: section.id,
+    title: 'Long task',
+    startAt: session.dayIso(1),
+    dueAt: session.dayIso(7),
+  });
+  const earlyTask = await createTask(session, project.id, {
+    sectionId: section.id,
+    title: 'Early task',
+    startAt: session.dayIso(1),
+    dueAt: session.dayIso(2),
+  });
+  const lateTask = await createTask(session, project.id, {
+    sectionId: section.id,
+    title: 'Late task',
+    startAt: session.dayIso(9),
+    dueAt: session.dayIso(10),
+  });
+
+  return {
+    projectId: project.id,
+    sectionId: section.id,
+    longTask,
+    earlyTask,
+    lateTask,
+  };
+}
+
+export async function seedResizeFixture(session: TimelineFixtureSession): Promise<ResizeFixture> {
+  const project = await createProject(session, 'Timeline Resize Fixture');
+  const section = await createSection(session, project.id, 'Resize Section');
+  const startAt = session.dayIso(2);
+  const dueAt = session.dayIso(3);
+  const resizedDueAt = session.dayIso(5);
+  const task = await createTask(session, project.id, {
+    sectionId: section.id,
+    title: 'Resize task',
+    startAt,
+    dueAt,
+  });
+
+  return {
+    projectId: project.id,
+    task,
+    startAt,
+    dueAt,
+    resizedDueAt,
+  };
+}
+
+export async function seedDatePersistenceFixture(
+  session: TimelineFixtureSession,
+): Promise<DatePersistenceFixture> {
+  const project = await createProject(session, 'Timeline Date Persistence Fixture');
+  const section = await createSection(session, project.id, 'Date Section');
+  const task = await createTask(session, project.id, {
+    sectionId: section.id,
+    title: 'Date persistence task',
+    startAt: session.dayIso(1),
+    dueAt: session.dayIso(3),
+  });
+
+  return {
+    projectId: project.id,
+    task,
+    nextStartDate: session.dayIso(3).slice(0, 10),
+    nextDueDate: session.dayIso(6).slice(0, 10),
+  };
+}
+
+export async function seedGroupedSubtasksFixture(
+  session: TimelineFixtureSession,
+): Promise<GroupedSubtasksFixture> {
+  const project = await createProject(session, 'Timeline Grouped Subtasks Fixture');
+  const sectionA = await createSection(session, project.id, 'Section A');
+  const sectionB = await createSection(session, project.id, 'Section B');
+  const parent = await createTask(session, project.id, {
+    sectionId: sectionA.id,
+    title: 'Grouped parent',
+    startAt: session.dayIso(1),
+    dueAt: session.dayIso(4),
+  });
+  const child = await createSubtask(session, parent.id, {
+    title: 'Grouped child',
+    startAt: session.dayIso(2),
+    dueAt: session.dayIso(2),
+  });
+
+  return {
+    projectId: project.id,
+    sectionAId: sectionA.id,
+    sectionBId: sectionB.id,
+    parent,
+    child,
+  };
+}
+
+export async function seedViewTransitionFixture(
+  session: TimelineFixtureSession,
+): Promise<ViewTransitionFixture> {
+  const project = await createProject(session, 'Timeline Gantt View Transition Fixture');
+  const sections = await listSections(session, project.id);
+  const defaultSection = sections.find((section) => section.isDefault) ?? sections[0];
+  if (!defaultSection) {
+    throw new Error('Expected a default section in the seeded project');
+  }
+
+  const earlierTask = await createTask(session, project.id, {
+    sectionId: defaultSection.id,
+    title: 'Boundary earlier',
+    startAt: session.dayIso(1),
+    dueAt: session.dayIso(2),
+  });
+  const laterTask = await createTask(session, project.id, {
+    sectionId: defaultSection.id,
+    title: 'Boundary later',
+    startAt: session.dayIso(1),
+    dueAt: session.dayIso(7),
+  });
+  await createDependency(session, laterTask.id, earlierTask.id);
+
+  return {
+    projectId: project.id,
+    defaultSectionId: defaultSection.id,
+    earlierTask,
+    laterTask,
+  };
+}
+
+export async function getTask(session: TimelineFixtureSession, taskId: string) {
+  return api<Task>(`/tasks/${taskId}`, session.token);
+}

--- a/e2e/playwright/tests/timeline-gantt-root-cause-fixtures.spec.ts
+++ b/e2e/playwright/tests/timeline-gantt-root-cause-fixtures.spec.ts
@@ -1,0 +1,416 @@
+import { expect, test, type Page } from '@playwright/test';
+import {
+  createTimelineFixtureSession,
+  getTask,
+  loginDevUser,
+  seedDatePersistenceFixture,
+  seedGroupedSubtasksFixture,
+  seedManualPlacementFixture,
+  seedResizeFixture,
+  seedViewTransitionFixture,
+} from './helpers/timeline-root-cause-fixtures';
+
+const DAY_COLUMN_WIDTH = 64;
+
+test.use({ timezoneId: 'Asia/Tokyo', locale: 'en-US' });
+
+async function timelineBarBox(page: Page, taskId: string) {
+  const bar = page.locator(`[data-testid="timeline-bar-${taskId}"]`).first();
+  await bar.scrollIntoViewIfNeeded();
+  await expect(bar).toBeVisible();
+  await expect
+    .poll(async () => {
+      const box = await bar.boundingBox();
+      return box ? { x: box.x, y: box.y, width: box.width, height: box.height } : null;
+    })
+    .not.toBeNull();
+  const box = await bar.boundingBox();
+  if (!box) {
+    throw new Error(`Unable to resolve bounds for timeline bar ${taskId}`);
+  }
+  return box;
+}
+
+async function timelineBarTop(page: Page, taskId: string) {
+  return (await timelineBarBox(page, taskId)).y;
+}
+
+async function waitForTimelineTask(page: Page, taskId: string) {
+  const bar = page.locator(`[data-testid="timeline-bar-${taskId}"]`).first();
+  await bar.waitFor({ state: 'visible' });
+  await expect
+    .poll(async () => {
+      const box = await bar.boundingBox();
+      return box ? { x: box.x, y: box.y, width: box.width, height: box.height } : null;
+    })
+    .not.toBeNull();
+}
+
+async function dragTimelineBarToTarget(page: Page, taskId: string, targetTestId: string) {
+  const barBox = await timelineBarBox(page, taskId);
+  const target = page.locator(`[data-testid="${targetTestId}"]`);
+  await expect(target).toBeVisible();
+  const targetBox = await target.boundingBox();
+  if (!targetBox) {
+    throw new Error(`Unable to resolve target bounds for ${targetTestId}`);
+  }
+
+  const startX = barBox.x + Math.min(Math.max(8, barBox.width / 4), barBox.width - 4);
+  const startY = barBox.y + barBox.height / 2;
+  const targetX = Math.min(Math.max(startX, targetBox.x + 18), targetBox.x + targetBox.width - 18);
+  const targetY = targetBox.y + targetBox.height / 2;
+
+  const bar = page.locator(`[data-testid="timeline-bar-${taskId}"]`).first();
+  await bar.dispatchEvent('pointerdown', {
+    button: 0,
+    clientX: startX,
+    clientY: startY,
+    pointerType: 'mouse',
+    isPrimary: true,
+    bubbles: true,
+  });
+  await page.evaluate(
+    ({ clientX, clientY }) => {
+      window.dispatchEvent(
+        new PointerEvent('pointermove', {
+          clientX,
+          clientY,
+          pointerType: 'mouse',
+          isPrimary: true,
+          bubbles: true,
+        }),
+      );
+      window.dispatchEvent(
+        new PointerEvent('pointerup', {
+          clientX,
+          clientY,
+          pointerType: 'mouse',
+          isPrimary: true,
+          bubbles: true,
+        }),
+      );
+    },
+    { clientX: targetX, clientY: targetY },
+  );
+}
+
+async function dragTimelineBarToLane(page: Page, taskId: string, laneTestId: string) {
+  const barBox = await timelineBarBox(page, taskId);
+  const lane = page.locator(`[data-testid="${laneTestId}"]`);
+  await expect(lane).toBeVisible();
+  const laneBox = await lane.boundingBox();
+  if (!laneBox) {
+    throw new Error(`Unable to resolve lane bounds for ${laneTestId}`);
+  }
+
+  const startX = barBox.x + Math.min(Math.max(8, barBox.width / 4), barBox.width - 4);
+  const startY = barBox.y + barBox.height / 2;
+  const targetY = laneBox.y + Math.min(Math.max(18, laneBox.height * 0.85), laneBox.height - 10);
+
+  const bar = page.locator(`[data-testid="timeline-bar-${taskId}"]`).first();
+  await bar.dispatchEvent('pointerdown', {
+    button: 0,
+    clientX: startX,
+    clientY: startY,
+    pointerType: 'mouse',
+    isPrimary: true,
+    bubbles: true,
+  });
+  await page.evaluate(
+    ({ clientX, clientY }) => {
+      window.dispatchEvent(
+        new PointerEvent('pointermove', {
+          clientX,
+          clientY,
+          pointerType: 'mouse',
+          isPrimary: true,
+          bubbles: true,
+        }),
+      );
+      window.dispatchEvent(
+        new PointerEvent('pointerup', {
+          clientX,
+          clientY,
+          pointerType: 'mouse',
+          isPrimary: true,
+          bubbles: true,
+        }),
+      );
+    },
+    { clientX: startX + 20, clientY: targetY },
+  );
+}
+
+async function resizeTimelineBar(page: Page, taskId: string, edge: 'start' | 'end', deltaDays: number) {
+  const bar = page.locator(`[data-testid="timeline-bar-${taskId}"]`).first();
+  await expect(bar).toBeVisible();
+  await bar.hover();
+
+  const handle = page.locator(`[data-testid="timeline-resize-${edge}-${taskId}"]`);
+  await expect(handle).toBeVisible();
+  const handleBox = await handle.boundingBox();
+  if (!handleBox) {
+    throw new Error(`Unable to resolve resize handle bounds for ${taskId}`);
+  }
+
+  const startX = handleBox.x + handleBox.width / 2;
+  const startY = handleBox.y + handleBox.height / 2;
+  await page.mouse.move(startX, startY);
+  await page.mouse.down();
+  await page.waitForTimeout(50);
+  await page.mouse.move(startX + deltaDays * DAY_COLUMN_WIDTH, startY, { steps: 18 });
+  await page.mouse.up();
+}
+
+async function clearTimelineViewState(
+  page: Page,
+  projectId: string,
+  userId: string,
+  mode: 'timeline' | 'gantt',
+) {
+  await page.evaluate(
+    ({ keys }) => {
+      for (const key of keys) {
+        window.localStorage.removeItem(key);
+      }
+    },
+    {
+      keys: [
+        `atlaspm:timeline-view:${projectId}:${mode}`,
+        `atlaspm:timeline-view:${projectId}:${mode}:${userId}`,
+        `atlaspm:timeline-view:${userId}:${projectId}:${mode}`,
+      ],
+    },
+  );
+}
+
+test('stable fixture keeps manual placement persisted after footer and row moves', async ({ page }) => {
+  const session = await createTimelineFixtureSession(page, 'e2e-root-fixture-manual');
+  const fixture = await seedManualPlacementFixture(session);
+
+  await page.goto(`/projects/${fixture.projectId}?view=timeline`);
+  await expect(page.locator('[data-testid="timeline-view"]')).toBeVisible();
+
+  await expect
+    .poll(async () => Math.abs((await timelineBarTop(page, fixture.earlyTask.id)) - (await timelineBarTop(page, fixture.lateTask.id))))
+    .toBeLessThanOrEqual(2);
+  await expect
+    .poll(async () => Math.abs((await timelineBarTop(page, fixture.longTask.id)) - (await timelineBarTop(page, fixture.earlyTask.id))))
+    .toBeGreaterThan(24);
+
+  const moveDownSave = page.waitForResponse((response) =>
+    response.url().includes(`/projects/${fixture.projectId}/timeline/preferences/manual-layout/section`) &&
+    response.request().method() === 'PUT' &&
+    response.ok(),
+  );
+  await dragTimelineBarToTarget(page, fixture.lateTask.id, `timeline-footer-row-section-${fixture.sectionId}`);
+  await moveDownSave;
+  await waitForTimelineTask(page, fixture.earlyTask.id);
+  await waitForTimelineTask(page, fixture.lateTask.id);
+  await expect
+    .poll(async () => (await timelineBarTop(page, fixture.lateTask.id)) - (await timelineBarTop(page, fixture.earlyTask.id)))
+    .toBeGreaterThan(24);
+
+  await page.reload();
+  await page.waitForLoadState('networkidle');
+  await waitForTimelineTask(page, fixture.earlyTask.id);
+  await waitForTimelineTask(page, fixture.lateTask.id);
+  await expect
+    .poll(async () => (await timelineBarTop(page, fixture.lateTask.id)) - (await timelineBarTop(page, fixture.earlyTask.id)))
+    .toBeGreaterThan(24);
+
+  const moveUpSave = page.waitForResponse((response) =>
+    response.url().includes(`/projects/${fixture.projectId}/timeline/preferences/manual-layout/section`) &&
+    response.request().method() === 'PUT' &&
+    response.ok(),
+  );
+  await dragTimelineBarToTarget(page, fixture.lateTask.id, `timeline-row-section-${fixture.sectionId}-0`);
+  await moveUpSave;
+  await waitForTimelineTask(page, fixture.earlyTask.id);
+  await waitForTimelineTask(page, fixture.lateTask.id);
+  await expect
+    .poll(async () => Math.abs((await timelineBarTop(page, fixture.lateTask.id)) - (await timelineBarTop(page, fixture.earlyTask.id))))
+    .toBeLessThanOrEqual(2);
+});
+
+test('stable fixture keeps resize, drawer dates, reload, and gantt aligned', async ({ page }) => {
+  const session = await createTimelineFixtureSession(page, 'e2e-root-fixture-resize');
+  const fixture = await seedResizeFixture(session);
+  const expectedStartDate = fixture.startAt.slice(0, 10);
+  const expectedResizedDueDate = fixture.resizedDueAt.slice(0, 10);
+  const expectedTitle = `${session.dateOnlyLabel(fixture.startAt)} - ${session.dateOnlyLabel(
+    fixture.resizedDueAt,
+  )}`;
+
+  await page.goto(`/projects/${fixture.projectId}?view=timeline`);
+  await expect(page.locator('[data-testid="timeline-view"]')).toBeVisible();
+  await page.click('[data-testid="timeline-zoom-day"]');
+  await expect(page.locator('[data-testid="timeline-zoom-day"]')).toHaveAttribute('data-active', 'true');
+
+  await resizeTimelineBar(page, fixture.task.id, 'end', 2);
+
+  await expect
+    .poll(async () => String((await getTask(session, fixture.task.id)).dueAt).slice(0, 10))
+    .toBe(expectedResizedDueDate);
+
+  await page.click(`[data-testid="timeline-bar-${fixture.task.id}"]`);
+  await expect(page.locator('[data-testid="task-detail-start-date"]')).toHaveValue(expectedStartDate);
+  await expect(page.locator('[data-testid="task-detail-due-date"]')).toHaveValue(expectedResizedDueDate);
+  await page.keyboard.press('Escape');
+
+  await page.reload();
+  await expect(page.locator('[data-testid="timeline-view"]')).toBeVisible();
+  await expect(page.locator(`[data-testid="timeline-bar-${fixture.task.id}"]`)).toHaveAttribute(
+    'title',
+    expectedTitle,
+  );
+
+  await page.click('[data-testid="project-view-gantt"]');
+  await expect(page).toHaveURL(new RegExp(`/projects/${fixture.projectId}.*view=gantt`));
+  await expect(page.locator('[data-testid="timeline-view"]')).toBeVisible();
+  await expect(page.locator(`[data-testid="timeline-bar-${fixture.task.id}"]`)).toHaveAttribute(
+    'title',
+    expectedTitle,
+  );
+});
+
+test('stable fixture persists drawer date inputs and reloads them', async ({ page }) => {
+  const session = await createTimelineFixtureSession(page, 'e2e-root-fixture-dates');
+  const fixture = await seedDatePersistenceFixture(session);
+  const startDateInput = page.locator('[data-testid="task-detail-start-date"]');
+  const dueDateInput = page.locator('[data-testid="task-detail-due-date"]');
+  const titleInput = page.locator('[data-testid="task-detail-title-input"]');
+
+  await page.goto(`/projects/${fixture.projectId}?view=timeline`);
+  await expect(page.locator('[data-testid="timeline-view"]')).toBeVisible();
+  await page.click(`[data-testid="timeline-bar-${fixture.task.id}"]`);
+  await expect(titleInput).toHaveValue(fixture.task.title);
+
+  await startDateInput.fill(fixture.nextStartDate);
+  await dueDateInput.click();
+  await expect
+    .poll(async () => String((await getTask(session, fixture.task.id)).startAt).slice(0, 10))
+    .toBe(fixture.nextStartDate);
+
+  await dueDateInput.fill(fixture.nextDueDate);
+  await titleInput.click();
+  await expect
+    .poll(async () => String((await getTask(session, fixture.task.id)).dueAt).slice(0, 10))
+    .toBe(fixture.nextDueDate);
+
+  await page.reload();
+  await expect(page.locator('[data-testid="timeline-view"]')).toBeVisible();
+  await page.click(`[data-testid="timeline-bar-${fixture.task.id}"]`);
+  await expect(startDateInput).toHaveValue(fixture.nextStartDate);
+  await expect(dueDateInput).toHaveValue(fixture.nextDueDate);
+});
+
+test('stable fixture blocks grouped subtasks from crossing section lanes', async ({ page }) => {
+  const session = await createTimelineFixtureSession(page, 'e2e-root-fixture-grouped');
+  const fixture = await seedGroupedSubtasksFixture(session);
+
+  await page.goto(`/projects/${fixture.projectId}?view=timeline`);
+  await expect(page.locator('[data-testid="timeline-view"]')).toBeVisible();
+
+  await dragTimelineBarToLane(page, fixture.child.id, `timeline-lane-section-${fixture.sectionBId}`);
+
+  await expect(page.locator('[data-testid="timeline-parent-move-warning-banner"]')).toContainText(
+    /同じグループ|same group/i,
+  );
+  await expect
+    .poll(async () => (await getTask(session, fixture.child.id)).sectionId)
+    .toBe(fixture.sectionAId);
+});
+
+test('stable fixture keeps timeline and gantt transitions isolated across saved state', async ({
+  browser,
+  page,
+}) => {
+  const session = await createTimelineFixtureSession(page, 'e2e-root-fixture-view');
+  const fixture = await seedViewTransitionFixture(session);
+
+  await page.goto(`/projects/${fixture.projectId}?view=timeline`);
+  await expect(page.locator('[data-testid="timeline-view"]')).toBeVisible();
+  await expect(page.locator('[data-testid="timeline-swimlane-toggle"]')).toBeVisible();
+  await expect(page.locator('[data-testid="timeline-sort-toggle"]')).toBeVisible();
+  await expect(page.locator('[data-testid="timeline-schedule-filter-toggle"]')).toBeVisible();
+  await expect(page.locator('[data-testid="gantt-risk-filter-toggle"]')).toHaveCount(0);
+  await expect(page.locator('[data-testid="gantt-strict-mode"]')).toHaveCount(0);
+
+  await page.click('[data-testid="timeline-swimlane-status"]');
+  await expect(page.locator('[data-testid="timeline-swimlane-status"]')).toHaveAttribute(
+    'data-active',
+    'true',
+  );
+  await page.click('[data-testid="timeline-zoom-month"]');
+  await expect(page.locator('[data-testid="timeline-zoom-month"]')).toHaveAttribute(
+    'data-active',
+    'true',
+  );
+
+  await page.click('[data-testid="project-view-gantt"]');
+  await expect(page).toHaveURL(new RegExp(`/projects/${fixture.projectId}.*view=gantt`));
+  await expect(page.locator('[data-testid="timeline-view"]')).toBeVisible();
+  await expect(page.locator('[data-testid="gantt-risk-filter-toggle"]')).toBeVisible();
+  await expect(page.locator('[data-testid="gantt-strict-mode"]')).toBeVisible();
+  await expect(page.locator('[data-testid="timeline-swimlane-toggle"]')).toHaveCount(0);
+  await expect(page.locator('[data-testid="timeline-sort-toggle"]')).toHaveCount(0);
+
+  await page.click('[data-testid="gantt-filter-risk"]');
+  await expect(page.locator('[data-testid="gantt-filter-risk"]')).toHaveAttribute('data-active', 'true');
+  await page.click('[data-testid="gantt-strict-mode"]');
+  await expect(page.locator('[data-testid="gantt-strict-mode"]')).toHaveAttribute('data-active', 'true');
+
+  const saveDefault = page.waitForResponse((response) =>
+    response.url().includes(`/projects/${fixture.projectId}/timeline/preferences/view-state/gantt`) &&
+    response.request().method() === 'PUT' &&
+    response.ok(),
+  );
+  await page.click('[data-testid="timeline-save-default"]');
+  await saveDefault;
+
+  const savedDefaultContext = await browser.newContext({ locale: 'en-US', timezoneId: 'Asia/Tokyo' });
+  const savedDefaultPage = await savedDefaultContext.newPage();
+  await loginDevUser(savedDefaultPage, session.userId, session.email);
+  await clearTimelineViewState(savedDefaultPage, fixture.projectId, session.userId, 'gantt');
+  await savedDefaultPage.goto(`/projects/${fixture.projectId}?view=gantt`);
+  await expect(savedDefaultPage.locator('[data-testid="gantt-filter-risk"]')).toHaveAttribute(
+    'data-active',
+    'true',
+  );
+  await expect(savedDefaultPage.locator('[data-testid="gantt-strict-mode"]')).toHaveAttribute(
+    'data-active',
+    'true',
+  );
+  await savedDefaultContext.close();
+
+  await page.click('[data-testid="project-view-timeline"]');
+  await expect(page.locator('[data-testid="timeline-swimlane-status"]')).toHaveAttribute(
+    'data-active',
+    'true',
+  );
+  await expect(page.locator('[data-testid="timeline-zoom-month"]')).toHaveAttribute(
+    'data-active',
+    'true',
+  );
+
+  await page.click('[data-testid="project-view-list"]');
+  await expect(page).toHaveURL(new RegExp(`/projects/${fixture.projectId}.*view=list`));
+  await expect(page.locator(`[data-task-title="${fixture.earlierTask.title}"]`)).toBeVisible();
+  await expect(page.locator(`[data-task-title="${fixture.laterTask.title}"]`)).toBeVisible();
+
+  await expect
+    .poll(async () => {
+      const titlesInOrder = await page
+        .locator(`[data-testid="section-${fixture.defaultSectionId}"] [data-task-title]`)
+        .evaluateAll((elements) =>
+          elements
+            .map((element) => element.getAttribute('data-task-title') ?? '')
+            .filter(Boolean),
+        );
+      const earlierIndex = titlesInOrder.indexOf(fixture.earlierTask.title);
+      const laterIndex = titlesInOrder.indexOf(fixture.laterTask.title);
+      return earlierIndex >= 0 && laterIndex >= 0 ? earlierIndex < laterIndex : false;
+    })
+    .toBe(true);
+});

--- a/e2e/playwright/tests/timeline-swimlane.spec.ts
+++ b/e2e/playwright/tests/timeline-swimlane.spec.ts
@@ -959,7 +959,7 @@ test('timeline grouped bars stay in sync with drawer date edits after drag resch
   const extendedDueDate = dayIso(5).slice(0, 10);
   const dueDateInput = page.locator('[data-testid="task-detail-due-date"]');
   await dueDateInput.fill(extendedDueDate);
-  await dueDateInput.blur();
+  await expect(dueDateInput).toHaveValue(extendedDueDate);
 
   await expect
     .poll(async () => {
@@ -977,7 +977,7 @@ test('timeline grouped bars stay in sync with drawer date edits after drag resch
   const widenedStartDate = dayIso(1).slice(0, 10);
   const startDateInput = page.locator('[data-testid="task-detail-start-date"]');
   await startDateInput.fill(widenedStartDate);
-  await startDateInput.blur();
+  await expect(startDateInput).toHaveValue(widenedStartDate);
 
   await expect
     .poll(async () => {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "type-check:collab-server": "pnpm --filter @atlaspm/collab-server type-check",
     "e2e:up": "./scripts/e2e-up.sh",
     "e2e": "./scripts/run-e2e.sh",
-    "e2e:timeline-gantt-rollout": "./scripts/run-e2e.sh tests/timeline-gantt-boundary.spec.ts tests/timeline-route.spec.ts tests/timeline-swimlane.spec.ts tests/gantt-risk.spec.ts tests/gantt-baseline.spec.ts tests/list-deadline-sort.spec.ts tests/rules.spec.ts tests/admin.spec.ts tests/collab.spec.ts",
+    "e2e:timeline-gantt-rollout": "./scripts/run-e2e.sh tests/timeline-gantt-boundary.spec.ts tests/timeline-route.spec.ts tests/timeline-swimlane.spec.ts tests/timeline-gantt-root-cause-fixtures.spec.ts tests/gantt-risk.spec.ts tests/gantt-baseline.spec.ts tests/list-deadline-sort.spec.ts tests/rules.spec.ts tests/admin.spec.ts tests/collab.spec.ts",
     "e2e:stability": "./scripts/e2e-stability.sh",
     "e2e:down": "./scripts/e2e-down.sh",
     "e2e:rebuild": "E2E_REBUILD=1 ./scripts/run-e2e.sh",


### PR DESCRIPTION
## Summary
- add deterministic Playwright project fixture builders for timeline/gantt root-cause scenarios
- cover manual placement, resize/date persistence, grouped subtasks, and timeline/gantt transitions in the rollout suite
- stabilize the existing grouped bar drawer-date assertion that was still retrying in the rollout gate

## Testing
- pnpm install
- pnpm e2e tests/timeline-date-only-semantics.spec.ts tests/timeline-root-cause.spec.ts
- pnpm e2e tests/timeline-gantt-root-cause-fixtures.spec.ts
- pnpm e2e tests/timeline-swimlane.spec.ts --grep "timeline grouped bars stay in sync with drawer date edits after drag reschedule" --repeat-each 2
- pnpm e2e tests/timeline-gantt-root-cause-fixtures.spec.ts --grep "stable fixture persists drawer date inputs and reloads them" --repeat-each 2
- pnpm e2e:timeline-gantt-rollout

Closes #269