### PR TITLE
fix(core-api): harden recurring retry idempotency

### DIFF
--- a/apps/core-api/src/recurring-tasks/recurring-task.worker.ts
+++ b/apps/core-api/src/recurring-tasks/recurring-task.worker.ts
@@ -410,6 +410,9 @@ export class RecurringTaskWorker implements OnModuleInit, OnModuleDestroy {
               id: generation.id,
               status: 'failed',
               taskId: null,
+              retryCount: {
+                lt: 3,
+              },
             },
             data: {
               status: 'pending',
@@ -498,8 +501,12 @@ export class RecurringTaskWorker implements OnModuleInit, OnModuleDestroy {
       } catch (retryError) {
         this.logger.error(`Retry failed for generation ${generation.id}:`, retryError);
 
-        await this.prisma.recurringTaskGeneration.update({
-          where: { id: generation.id },
+        await this.prisma.recurringTaskGeneration.updateMany({
+          where: {
+            id: generation.id,
+            status: 'failed',
+            taskId: null,
+          },
           data: {
             status: 'failed',
             retryCount: {

--- a/apps/core-api/test/recurring-task.worker.test.ts
+++ b/apps/core-api/test/recurring-task.worker.test.ts
@@ -162,7 +162,88 @@ describe('RecurringTaskWorker', () => {
     expect(second).toEqual({ retried: 1, succeeded: 0 });
     expect(tx.task.create).toHaveBeenCalledTimes(1);
     expect(tx.recurringTaskGeneration.updateMany).toHaveBeenCalledTimes(2);
+    expect(tx.recurringTaskGeneration.updateMany).toHaveBeenCalledWith({
+      where: {
+        id: generation.id,
+        status: 'failed',
+        taskId: null,
+        retryCount: {
+          lt: 3,
+        },
+      },
+      data: {
+        status: 'pending',
+      },
+    });
     expect(tx.recurringTaskGeneration.update).toHaveBeenCalledTimes(1);
+    expect(prisma.recurringTaskGeneration.update).not.toHaveBeenCalled();
+  });
+
+  it('does not mark a completed generation back to failed after a retry error race', async () => {
+    const generation = {
+      id: 'gen-failed',
+      ruleId: baseRule.id,
+      scheduledAt: new Date('2026-03-05T00:00:00.000Z'),
+      status: 'failed',
+      retryCount: 0,
+      error: 'transient failure',
+    };
+
+    const tx = {
+      task: {
+        create: vi.fn(async () => {
+          throw new Error('task create failed');
+        }),
+      },
+      recurringTaskGeneration: {
+        updateMany: vi.fn(async () => ({ count: 1 })),
+        update: vi.fn(async () => undefined),
+      },
+      recurringRule: {
+        update: vi.fn(async () => undefined),
+      },
+    };
+
+    const prisma = {
+      recurringTaskGeneration: {
+        findMany: vi.fn(async () => [generation]),
+        updateMany: vi.fn(async () => ({ count: 0 })),
+        update: vi.fn(async () => undefined),
+      },
+      recurringRule: {
+        findFirst: vi.fn(async () => ({
+          ...baseRule,
+          isActive: true,
+        })),
+      },
+      task: {
+        findFirst: vi.fn(async () => null),
+      },
+      $transaction: vi.fn(async (callback) => callback(tx)),
+    };
+
+    const domain = {
+      appendAuditOutbox: vi.fn(async () => undefined),
+    };
+
+    const worker = new RecurringTaskWorker(prisma as any, domain as any);
+
+    const result = await worker.retryFailedGenerations();
+
+    expect(result).toEqual({ retried: 1, succeeded: 0 });
+    expect(prisma.recurringTaskGeneration.updateMany).toHaveBeenCalledWith({
+      where: {
+        id: generation.id,
+        status: 'failed',
+        taskId: null,
+      },
+      data: {
+        status: 'failed',
+        retryCount: {
+          increment: 1,
+        },
+      },
+    });
     expect(prisma.recurringTaskGeneration.update).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- atomically claim failed recurring generations before retry task creation
- add a focused worker regression test for concurrent retry attempts
- keep recurrence worker/controller/policy verification green

## Testing
- pnpm --filter @atlaspm/core-api exec vitest run test/recurring-task.worker.test.ts test/recurring-tasks.controller.test.ts test/recurrence-policy.test.ts
- pnpm --filter @atlaspm/core-api type-check

Refs #275