### PR TITLE
P5-3: Add operational hardening for migrations, jobs, and observability (#286)

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -5,30 +5,48 @@
 - Branch: codex/reopen-issue-286
 - Workspace: /home/tommy/Dev/atlaspm-worktrees/issue-286
 - Journal: /home/tommy/Dev/atlaspm-worktrees/issue-286/.codex-supervisor/issue-journal.md
-- Current phase: reproducing
-- Attempt count: 1
-- Last head SHA: f43ae534d58285d1908a0d7a7ac522618e95fefc
+- Current phase: addressing_review
+- Attempt count: 2
+- Last head SHA: 521c3f4d1304d654f516c66fe21ab91dbe186400
 - Blocked reason: none
-- Last failure signature: none
-- Repeated failure signature count: 0
-- Updated at: 2026-03-09T02:30:47.466Z
+- Last failure signature: PRRT_kwDORWcwRc5y6G0v|PRRT_kwDORWcwRc5y6G02|PRRT_kwDORWcwRc5y6G08|PRRT_kwDORWcwRc5y6G1B
+- Repeated failure signature count: 1
+- Updated at: 2026-03-09T02:40:07.433Z
 
 ## Latest Codex Summary
-- None yet.
+Added a checkpoint commit on `codex/reopen-issue-286`: `521c3f4` (`Add migration preflight and request log hardening`).
+
+The focused reproducer was a new test proving `http.request.start` logs were missing `userId`; that is now fixed in [request-logging.middleware.ts](/home/tommy/Dev/atlaspm-worktrees/issue-286/apps/core-api/src/common/request-logging.middleware.ts). I also added a Prisma startup preflight in [migration-health.ts](/home/tommy/Dev/atlaspm-worktrees/issue-286/apps/core-api/src/prisma/migration-health.ts) and wired it through [prisma.service.ts](/home/tommy/Dev/atlaspm-worktrees/issue-286/apps/core-api/src/prisma/prisma.service.ts) so startup now logs structured migration health, warns on pending/extra migrations, and blocks startup on failed migrations with explicit recovery guidance. The new tests are in [request-logging.middleware.test.ts](/home/tommy/Dev/atlaspm-worktrees/issue-286/apps/core-api/test/request-logging.middleware.test.ts) and [migration-health.test.ts](/home/tommy/Dev/atlaspm-worktrees/issue-286/apps/core-api/test/migration-health.test.ts).
+
+Verification was focused and clean after generating Prisma client: `pnpm exec vitest run test/request-logging.middleware.test.ts test/migration-health.test.ts`, `pnpm prisma:generate`, and `pnpm type-check`. I also updated [.codex-supervisor/issue-journal.md](/home/tommy/Dev/atlaspm-worktrees/issue-286/.codex-supervisor/issue-journal.md) with the repro, commands, and next step.
+
+Summary: Added a reproducing test and fix for missing request-start `userId` logs, plus Prisma migration-health startup diagnostics and guardrails; committed as `521c3f4`.
+State hint: implementing
+Blocked reason: none
+Tests: `cd apps/core-api && pnpm exec vitest run test/request-logging.middleware.test.ts test/migration-health.test.ts`; `cd apps/core-api && pnpm prisma:generate`; `cd apps/core-api && pnpm type-check`
+Failure signature: none
+Next action: Add the next narrow reproducer around background job failure/completion diagnostics and extend structured job observability in the same style.
 
 ## Active Failure Context
-- None recorded.
+- Category: review
+- Summary: 4 unresolved automated review thread(s) remain.
+- Reference: https://github.com/TommyKammy/atlaspm/pull/307#discussion_r2902900985
+- Details:
+  - apps/core-api/src/common/request-logging.middleware.ts:7 `userId` is captured before Nest guards run. In this app, `AuthGuard` sets `req.user` during `canActivate`, which happens after Express middleware registration in `main.ts`, so `userId` here will almost always be `'anonymous'` and this change will also regress the `http.request.end` log (it previously could pick up `req.user` by the time `finish` fires). Consider computing `userId` inside the `finish` callback (for the end log), and if you truly need `userId` on the start event, move the start logging to a Nest interceptor/guard that runs after authentication rather than Express middleware.
+  - apps/core-api/test/request-logging.middleware.test.ts:30 This test pre-populates `request.user` before invoking the Express middleware, but in production `req.user` is populated by `AuthGuard.canActivate` (after middleware), so `http.request.start` will not see a user and this test will give false confidence. To match real behavior, start with no `user`, then set `request.user` before triggering the captured `finish` listener; assert that the end log includes the authenticated `userId` and decide whether the start log should omit `userId` or use a sentinel like `'unknown'`.
+  - apps/core-api/src/prisma/prisma.service.ts:22 `inspectMigrationHealth()` can throw (e.g., missing `prisma/migrations` directory at runtime, or `_prisma_migrations` table not present / insufficient privileges). Right now any such error will crash startup without producing the structured health output you intended. Consider wrapping the migration-health probe in a try/catch that logs a clear, operator-actionable warning/error (and decide explicitly whether to fail open or fail closed for probe failures).
+  - apps/core-api/src/prisma/migration-health.ts:36 This uses `$queryRawUnsafe` even though the SQL is static. Using the safe `$queryRaw` API (e.g., with `Prisma.sql`) avoids normalizing an unsafe pattern into the codebase and makes it harder to accidentally introduce SQL injection later if the query becomes parameterized.
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: Operators lacked two concrete diagnostics: request-start logs were missing `userId`, and startup had no explicit Prisma migration-health preflight to surface pending/failed migrations with recovery guidance.
-- Primary failure or risk: `RequestLoggingMiddleware` emitted `http.request.start` without `userId`; `PrismaService` connected without checking `_prisma_migrations`, so failed/pending migrations were not summarized at startup.
-- Last focused command: `cd /home/tommy/Dev/atlaspm-worktrees/issue-286/apps/core-api && pnpm type-check`
-- Files changed: `apps/core-api/src/common/request-logging.middleware.ts`, `apps/core-api/src/prisma/prisma.service.ts`, `apps/core-api/src/prisma/migration-health.ts`, `apps/core-api/test/request-logging.middleware.test.ts`, `apps/core-api/test/migration-health.test.ts`
+- Hypothesis: The valid review fixes are to align request logging with actual Nest auth timing and to make the migration-health probe fail open with structured diagnostics while still failing closed for confirmed failed migrations.
+- Primary failure or risk: Review threads identified an incorrect middleware assumption (`req.user` not available at request start), unsafe `$queryRawUnsafe` usage for a static query, and missing probe-error handling that could crash startup without actionable output.
+- Last focused command: `cd /home/tommy/Dev/atlaspm-worktrees/issue-286/apps/core-api && pnpm prisma:generate && pnpm type-check`
+- Files changed: `apps/core-api/src/common/request-logging.middleware.ts`, `apps/core-api/src/prisma/prisma.service.ts`, `apps/core-api/src/prisma/migration-health.ts`, `apps/core-api/test/request-logging.middleware.test.ts`, `apps/core-api/test/migration-health.test.ts`, `docs/architecture.md`
 - Next 1-3 actions:
-  1. Commit the observability + migration-health checkpoint.
-  2. Decide whether to extend the same hardening pattern to job worker completion/failure summaries.
-  3. If continuing, add the next narrow reproducer around job failure diagnostics.
+  1. Commit the review fixes for request logging and migration probe handling.
+  2. Update the PR branch and resolve the automated review threads.
+  3. If more review arrives, keep the next change narrowly scoped to the cited behavior.
 
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.
@@ -37,3 +55,8 @@
   - `cd apps/core-api && pnpm exec vitest run test/request-logging.middleware.test.ts test/migration-health.test.ts`
   - `cd apps/core-api && pnpm prisma:generate`
   - `cd apps/core-api && pnpm type-check`
+- Review fixes applied:
+  - request-start logs no longer claim `userId`; request-end still captures `req.user` after guards.
+  - migration-health now uses `$queryRaw` with `Prisma.sql`.
+  - startup wraps migration probe failures and emits `prisma.migrations.probe_failed` warnings instead of crashing on probe-only errors.
+  - default migrations path now resolves relative to `src/prisma`/`dist/prisma`, not process cwd.

--- a/apps/core-api/src/common/request-logging.middleware.ts
+++ b/apps/core-api/src/common/request-logging.middleware.ts
@@ -3,7 +3,6 @@ import type { NextFunction, Request, Response } from 'express';
 export class RequestLoggingMiddleware {
   use(req: Request & { correlationId?: string; user?: { sub?: string } }, res: Response, next: NextFunction) {
     const correlationId = req.correlationId ?? 'unknown';
-    const userId = req.user?.sub ?? 'anonymous';
     const startedAt = Date.now();
     console.info(
       JSON.stringify({
@@ -13,12 +12,12 @@ export class RequestLoggingMiddleware {
         path: req.path,
         query: req.query,
         correlationId,
-        userId,
       }),
     );
 
     res.on('finish', () => {
       const durationMs = Date.now() - startedAt;
+      const userId = req.user?.sub ?? 'anonymous';
       console.info(
         JSON.stringify({
           level: 'info',

--- a/apps/core-api/src/prisma/migration-health.ts
+++ b/apps/core-api/src/prisma/migration-health.ts
@@ -1,8 +1,9 @@
 import { readdir } from 'node:fs/promises';
-import { basename, resolve } from 'node:path';
+import { resolve } from 'node:path';
+import { Prisma } from '@prisma/client';
 
 type MigrationQueryClient = {
-  $queryRawUnsafe<T = unknown>(query: string): Promise<T>;
+  $queryRaw<T = unknown>(query: Prisma.Sql): Promise<T>;
 };
 
 type MigrationRow = {
@@ -23,16 +24,15 @@ export type MigrationHealthSummary = {
 
 export async function inspectMigrationHealth(
   prisma: MigrationQueryClient,
-  migrationsDir = resolve(process.cwd(), 'prisma', 'migrations'),
+  migrationsDir = resolve(__dirname, '../../prisma/migrations'),
 ): Promise<MigrationHealthSummary> {
   const localMigrationNames = (await readdir(migrationsDir, { withFileTypes: true }))
     .filter((entry) => entry.isDirectory())
     .map((entry) => entry.name)
-    .filter((name) => name !== basename(migrationsDir))
     .sort();
 
-  const rows = await prisma.$queryRawUnsafe<MigrationRow[]>(
-    'SELECT migration_name, finished_at, rolled_back_at, logs FROM "_prisma_migrations" ORDER BY migration_name ASC',
+  const rows = await prisma.$queryRaw<MigrationRow[]>(
+    Prisma.sql`SELECT migration_name, finished_at, rolled_back_at, logs FROM "_prisma_migrations" ORDER BY migration_name ASC`,
   );
 
   const appliedRows = rows.filter((row) => row.finished_at && !row.rolled_back_at);
@@ -102,4 +102,14 @@ export function formatMigrationHealth(summary: MigrationHealthSummary) {
 
 export function shouldBlockStartupForMigrationHealth(summary: MigrationHealthSummary) {
   return summary.failedDatabaseMigrations.length > 0;
+}
+
+export function formatMigrationHealthProbeFailure(error: unknown, migrationsDir: string) {
+  return JSON.stringify({
+    event: 'prisma.migrations.probe_failed',
+    migrationsDir,
+    error: error instanceof Error ? error.message : String(error),
+    warning:
+      'Unable to inspect Prisma migration health during startup. Verify the migrations directory, database permissions, and "_prisma_migrations" table state.',
+  });
 }

--- a/apps/core-api/src/prisma/prisma.service.ts
+++ b/apps/core-api/src/prisma/prisma.service.ts
@@ -1,8 +1,11 @@
 import { INestApplication, Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { resolve } from 'node:path';
 import { PrismaClient } from '@prisma/client';
 import {
+  formatMigrationHealthProbeFailure,
   formatMigrationHealth,
   inspectMigrationHealth,
+  type MigrationHealthSummary,
   shouldBlockStartupForMigrationHealth,
 } from './migration-health';
 
@@ -12,8 +15,16 @@ export class PrismaService extends PrismaClient implements OnModuleInit {
 
   async onModuleInit() {
     await this.$connect();
+    const migrationsDir = this.resolveMigrationsDir();
+    let summary: MigrationHealthSummary;
 
-    const summary = await inspectMigrationHealth(this);
+    try {
+      summary = await inspectMigrationHealth(this, migrationsDir);
+    } catch (error) {
+      this.logger.warn(formatMigrationHealthProbeFailure(error, migrationsDir));
+      return;
+    }
+
     const message = formatMigrationHealth(summary);
 
     if (shouldBlockStartupForMigrationHealth(summary)) {
@@ -33,5 +44,9 @@ export class PrismaService extends PrismaClient implements OnModuleInit {
     process.on('beforeExit', () => {
       void app.close();
     });
+  }
+
+  private resolveMigrationsDir() {
+    return resolve(__dirname, '../../prisma/migrations');
   }
 }

--- a/apps/core-api/test/migration-health.test.ts
+++ b/apps/core-api/test/migration-health.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, test, vi } from 'vitest';
 import {
+  formatMigrationHealthProbeFailure,
   formatMigrationHealth,
   inspectMigrationHealth,
   shouldBlockStartupForMigrationHealth,
@@ -25,7 +26,7 @@ describe('migration health', () => {
     ]);
 
     const prisma = {
-      $queryRawUnsafe: vi.fn().mockResolvedValue([
+      $queryRaw: vi.fn().mockResolvedValue([
         {
           migration_name: '202602230001_init',
           finished_at: new Date('2026-02-23T00:01:00.000Z'),
@@ -48,7 +49,7 @@ describe('migration health', () => {
     const migrationsDir = createMigrationsDir(['202602230001_init']);
 
     const prisma = {
-      $queryRawUnsafe: vi.fn().mockResolvedValue([
+      $queryRaw: vi.fn().mockResolvedValue([
         {
           migration_name: '202602230001_init',
           finished_at: null,
@@ -71,6 +72,17 @@ describe('migration health', () => {
     expect(message).toContain('"event":"prisma.migrations.attention_required"');
     expect(message).toContain('"hasLogs":true');
     expect(message).toContain('Failed Prisma migrations detected');
+  });
+
+  test('formats probe failures with actionable structured warnings', () => {
+    const message = formatMigrationHealthProbeFailure(
+      new Error('permission denied for relation _prisma_migrations'),
+      '/srv/atlaspm/apps/core-api/prisma/migrations',
+    );
+
+    expect(message).toContain('"event":"prisma.migrations.probe_failed"');
+    expect(message).toContain('/srv/atlaspm/apps/core-api/prisma/migrations');
+    expect(message).toContain('permission denied for relation _prisma_migrations');
   });
 
   function createMigrationsDir(migrationNames: string[]) {

--- a/apps/core-api/test/request-logging.middleware.test.ts
+++ b/apps/core-api/test/request-logging.middleware.test.ts
@@ -19,14 +19,13 @@ describe('RequestLoggingMiddleware', () => {
     vi.restoreAllMocks();
   });
 
-  test('logs user identity on request start and end', () => {
+  test('logs authenticated user identity on request end after guards populate req.user', () => {
     const middleware = new RequestLoggingMiddleware();
     const request: RequestLike = {
       method: 'GET',
       path: '/tasks',
       query: { projectId: 'project-1' },
       correlationId: 'corr-123',
-      user: { sub: 'user-123' },
     };
 
     let finishListener: (() => void) | undefined;
@@ -43,6 +42,7 @@ describe('RequestLoggingMiddleware', () => {
     const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined);
 
     middleware.use(request as never, response as never, next);
+    request.user = { sub: 'user-123' };
     finishListener?.();
 
     expect(next).toHaveBeenCalledTimes(1);
@@ -56,8 +56,8 @@ describe('RequestLoggingMiddleware', () => {
       path: '/tasks',
       query: { projectId: 'project-1' },
       correlationId: 'corr-123',
-      userId: 'user-123',
     });
+    expect(startLog.userId).toBeUndefined();
 
     const endLog = JSON.parse(infoSpy.mock.calls[1][0] as string);
     expect(endLog).toMatchObject({

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -23,7 +23,7 @@
   - `core-api` accepts `x-correlation-id` (or generates one), stores it on request context, and returns it in response headers.
   - `collab-server` sends `x-correlation-id` when loading/saving snapshots to `core-api`.
 - Structured logs:
-  - `core-api` emits request start/end logs with `method`, `path`, `statusCode`, `durationMs`, `userId`, and `correlationId`.
+  - `core-api` emits `http.request.start` with `method`, `path`, `query`, and `correlationId`, then `http.request.end` with `statusCode`, `durationMs`, `userId`, and the same `correlationId` after auth has populated the request context.
   - `collab-server` emits auth/presence/snapshot logs with `correlationId`, `roomId`, and `taskId`.
 - Traceability target:
   - A single user action can be traced from HTTP request logs to audit/outbox entries and collab snapshot logs by `correlationId`.


### PR DESCRIPTION
Closes #286
This PR was opened by codex-supervisor.
Latest Codex summary:

Added a checkpoint commit on `codex/reopen-issue-286`: `521c3f4` (`Add migration preflight and request log hardening`).

The focused reproducer was a new test proving `http.request.start` logs were missing `userId`; that is now fixed in [request-logging.middleware.ts](/home/tommy/Dev/atlaspm-worktrees/issue-286/apps/core-api/src/common/request-logging.middleware.ts). I also added a Prisma startup preflight in [migration-health.ts](/home/tommy/Dev/atlaspm-worktrees/issue-286/apps/core-api/src/prisma/migration-health.ts) and wired it through [prisma.service.ts](/home/tommy/Dev/atlaspm-worktrees/issue-286/apps/core-api/src/prisma/prisma.service.ts) so startup now logs structured migration health, warns on pending/extra migrations, and blocks startup on failed migrations with explicit recovery guidance. The new tests are in [request-logging.middleware.test.ts](/home/tommy/Dev/atlaspm-worktrees/issue-286/apps/core-api/test/request-logging.middleware.test.ts) and [migration-health.test.ts](/home/tommy/Dev/atlaspm-worktrees/issue-286/apps/core-api/test/migration-health.test.ts).

Verification was focused and clean after generating Prisma client: `pnpm exec vitest run test/request-logging.middleware.test.ts test/migration-health.test.ts`, `pnpm prisma:generate`, and `pnpm type-check`. I also updated [.codex-supervisor/issue-journal.md](/home/tommy/Dev/atlaspm-worktrees/issue-286/.codex-supervisor/issue-journal.md) with the repro, commands, and next step.

Summary: Added a reproduc...