### PR TITLE
test: add saved-view fallback and transition coverage

### DIFF
--- a/apps/core-api/src/projects/project-views.controller.ts
+++ b/apps/core-api/src/projects/project-views.controller.ts
@@ -24,6 +24,7 @@ import {
 import {
   PROJECT_VIEW_MODES,
   normalizeProjectViewState,
+  type ProjectViewCustomFieldFilter,
   type ProjectViewMode,
   type ProjectViewState,
 } from '@atlaspm/domain';
@@ -62,6 +63,17 @@ class PatchProjectSavedViewDto {
 }
 
 type ProjectViewDbClient = Prisma.TransactionClient;
+type ProjectViewReadClient = Pick<PrismaService, 'projectMembership' | 'customFieldDefinition'>;
+type ProjectViewValidationContext = {
+  validAssigneeIds: Set<string>;
+  customFieldsById: Map<
+    string,
+    {
+      type: CustomFieldType;
+      optionIds: Set<string>;
+    }
+  >;
+};
 
 @Controller()
 @UseGuards(AuthGuard)
@@ -259,7 +271,7 @@ export class ProjectViewsController {
   }
 
   private async buildSavedViewsResponse(projectId: string, userId: string) {
-    const [preferences, views] = await Promise.all([
+    const [preferences, views, validationContext] = await Promise.all([
       this.prisma.projectViewPreference.findMany({
         where: { projectId, userId },
       }),
@@ -267,17 +279,21 @@ export class ProjectViewsController {
         where: { projectId, userId },
         orderBy: [{ createdAt: 'asc' }, { id: 'asc' }],
       }),
+      this.loadProjectViewValidationContext(this.prisma, projectId),
     ]);
 
     return {
       projectId,
       userId,
-      defaultsByMode: this.serializeDefaultsByMode(preferences),
-      views: views.map((view) => this.serializeSavedView(view)),
+      defaultsByMode: this.serializeDefaultsByMode(preferences, validationContext),
+      views: views.map((view) => this.serializeSavedView(view, validationContext)),
     };
   }
 
-  private serializeDefaultsByMode(preferences: ProjectViewPreference[]) {
+  private serializeDefaultsByMode(
+    preferences: ProjectViewPreference[],
+    validationContext: ProjectViewValidationContext,
+  ) {
     const defaultsByMode: Record<ProjectViewMode, ProjectViewState | null> = {
       list: null,
       board: null,
@@ -290,13 +306,14 @@ export class ProjectViewsController {
         continue;
       }
       const mode = preference.mode as ProjectViewMode;
-      defaultsByMode[mode] = this.normalizePersistedProjectViewState(mode, preference.state);
+      const state = this.sanitizePersistedProjectViewState(mode, preference.state, validationContext);
+      defaultsByMode[mode] = Object.keys(state).length > 0 ? state : null;
     }
 
     return defaultsByMode;
   }
 
-  private serializeSavedView(view: ProjectSavedView) {
+  private serializeSavedView(view: ProjectSavedView, validationContext?: ProjectViewValidationContext) {
     const mode = this.parseProjectViewMode(view.mode);
     return {
       id: view.id,
@@ -304,7 +321,9 @@ export class ProjectViewsController {
       userId: view.userId,
       name: view.name,
       mode,
-      state: this.normalizePersistedProjectViewState(mode, view.state),
+      state: validationContext
+        ? this.sanitizePersistedProjectViewState(mode, view.state, validationContext)
+        : this.normalizePersistedProjectViewState(mode, view.state),
       createdAt: view.createdAt,
       updatedAt: view.updatedAt,
     };
@@ -346,6 +365,62 @@ export class ProjectViewsController {
     return normalizeProjectViewState(mode, rawState as Partial<ProjectViewState>);
   }
 
+  private sanitizePersistedProjectViewState(
+    mode: ProjectViewMode,
+    rawState: Prisma.JsonValue,
+    validationContext: ProjectViewValidationContext,
+  ): ProjectViewState {
+    const normalizedState = this.normalizePersistedProjectViewState(mode, rawState);
+    const filters = normalizedState.filters;
+
+    if (!filters) {
+      return normalizedState;
+    }
+
+    const sanitizedFilters: NonNullable<ProjectViewState['filters']> = { ...filters };
+
+    if (sanitizedFilters.assigneeIds?.length) {
+      sanitizedFilters.assigneeIds = sanitizedFilters.assigneeIds.filter((assigneeId) =>
+        validationContext.validAssigneeIds.has(assigneeId),
+      );
+      if (!sanitizedFilters.assigneeIds.length) {
+        delete sanitizedFilters.assigneeIds;
+      }
+    }
+
+    if (sanitizedFilters.customFieldFilters?.length) {
+      sanitizedFilters.customFieldFilters = sanitizedFilters.customFieldFilters
+        .map((filter) => {
+          const field = validationContext.customFieldsById.get(filter.fieldId);
+          if (!field || field.type !== (filter.type as CustomFieldType)) {
+            return null;
+          }
+
+          if (filter.type === 'SELECT') {
+            const optionIds = (filter.optionIds ?? []).filter((optionId) => field.optionIds.has(optionId));
+            return optionIds.length ? { ...filter, optionIds } : null;
+          }
+
+          return filter;
+        })
+        .filter((filter): filter is ProjectViewCustomFieldFilter => Boolean(filter));
+
+      if (!sanitizedFilters.customFieldFilters.length) {
+        delete sanitizedFilters.customFieldFilters;
+      }
+    }
+
+    const nextState: ProjectViewState = {
+      ...normalizedState,
+      filters: Object.keys(sanitizedFilters).length > 0 ? sanitizedFilters : undefined,
+    };
+    if (!nextState.filters) {
+      delete nextState.filters;
+    }
+
+    return normalizeProjectViewState(mode, nextState);
+  }
+
   private async normalizeAndValidateProjectViewState(
     tx: ProjectViewDbClient,
     projectId: string,
@@ -362,6 +437,43 @@ export class ProjectViewsController {
     await this.validateCustomFieldFilters(tx, projectId, normalizedState);
 
     return normalizedState as Prisma.JsonObject;
+  }
+
+  private async loadProjectViewValidationContext(
+    client: ProjectViewReadClient,
+    projectId: string,
+  ): Promise<ProjectViewValidationContext> {
+    const [memberships, fields] = await Promise.all([
+      client.projectMembership.findMany({
+        where: { projectId },
+        select: { userId: true },
+      }),
+      client.customFieldDefinition.findMany({
+        where: {
+          projectId,
+          archivedAt: null,
+        },
+        include: {
+          options: {
+            where: { archivedAt: null },
+            select: { id: true },
+          },
+        },
+      }),
+    ]);
+
+    return {
+      validAssigneeIds: new Set(memberships.map((membership) => membership.userId)),
+      customFieldsById: new Map(
+        fields.map((field) => [
+          field.id,
+          {
+            type: field.type,
+            optionIds: new Set(field.options.map((option) => option.id)),
+          },
+        ]),
+      ),
+    };
   }
 
   private async validateStatusIds(state: ProjectViewState) {

--- a/apps/core-api/test/core.integration.test.ts
+++ b/apps/core-api/test/core.integration.test.ts
@@ -4411,6 +4411,141 @@ describe('Core API Integration', () => {
     expect(deletedAudit).toBeTruthy();
   });
 
+  test('saved view list sanitizes stale assignee and custom field references for fallback resolution', async () => {
+    const workspaceRes = await request(app.getHttpServer())
+      .get('/workspaces')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+    const workspaceId = workspaceRes.body[0].id as string;
+
+    const projectRes = await request(app.getHttpServer())
+      .post('/projects')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ workspaceId, name: 'Saved View Fallback Project' })
+      .expect(201);
+    const projectId = projectRes.body.id as string;
+
+    const validAssigneeId = `saved-view-fallback-member-${projectId}`;
+    await prisma.user.upsert({
+      where: { id: validAssigneeId },
+      create: {
+        id: validAssigneeId,
+        email: `${validAssigneeId}@example.com`,
+        displayName: 'Saved View Fallback Member',
+        status: 'ACTIVE',
+      },
+      update: {},
+    });
+    await prisma.workspaceMembership.upsert({
+      where: { workspaceId_userId: { workspaceId, userId: validAssigneeId } },
+      create: { workspaceId, userId: validAssigneeId, role: 'WS_MEMBER' },
+      update: {},
+    });
+    await prisma.projectMembership.upsert({
+      where: { projectId_userId: { projectId, userId: validAssigneeId } },
+      create: { projectId, userId: validAssigneeId, role: 'VIEWER' },
+      update: {},
+    });
+
+    const staleField = await prisma.customFieldDefinition.create({
+      data: {
+        projectId,
+        name: 'Fallback Bucket',
+        type: 'SELECT',
+        position: 1000,
+        options: {
+          create: [
+            { label: 'Keep', value: 'keep', position: 1000 },
+            { label: 'Drop', value: 'drop', position: 2000 },
+          ],
+        },
+      },
+      include: {
+        options: {
+          where: { archivedAt: null },
+          orderBy: [{ position: 'asc' }, { createdAt: 'asc' }],
+        },
+      },
+    });
+    const staleOptionId = staleField.options[0]?.id;
+    expect(staleOptionId).toBeTruthy();
+
+    await request(app.getHttpServer())
+      .put(`/projects/${projectId}/saved-views/defaults/list`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        state: {
+          grouping: { field: 'section' },
+          sorting: { field: 'position', direction: 'asc' },
+          filters: {
+            assigneeIds: [validAssigneeId],
+            customFieldFilters: [
+              {
+                fieldId: staleField.id,
+                type: 'SELECT',
+                optionIds: [staleOptionId],
+              },
+            ],
+          },
+          visibleFieldIds: ['name', 'status'],
+        },
+      })
+      .expect(200);
+
+    const namedViewRes = await request(app.getHttpServer())
+      .post(`/projects/${projectId}/saved-views`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        name: 'Stale only',
+        mode: 'list',
+        state: {
+          filters: {
+            assigneeIds: [validAssigneeId],
+            customFieldFilters: [
+              {
+                fieldId: staleField.id,
+                type: 'SELECT',
+                optionIds: [staleOptionId],
+              },
+            ],
+          },
+        },
+      })
+      .expect(201);
+
+    await prisma.projectMembership.delete({
+      where: {
+        projectId_userId: {
+          projectId,
+          userId: validAssigneeId,
+        },
+      },
+    });
+    await prisma.customFieldOption.update({
+      where: { id: staleOptionId },
+      data: { archivedAt: new Date() },
+    });
+
+    const savedViewsRes = await request(app.getHttpServer())
+      .get(`/projects/${projectId}/saved-views`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+
+    expect(savedViewsRes.body.defaultsByMode.list).toEqual({
+      grouping: { field: 'section' },
+      sorting: { field: 'position', direction: 'asc' },
+      visibleFieldIds: ['name', 'status'],
+    });
+    expect(savedViewsRes.body.views).toEqual([
+      expect.objectContaining({
+        id: namedViewRes.body.id,
+        name: 'Stale only',
+        mode: 'list',
+        state: {},
+      }),
+    ]);
+  });
+
   test('timeline manual layout preserves legacy per-swimlane task order state when upgrading from #232', async () => {
     const workspaceRes = await request(app.getHttpServer())
       .get('/workspaces')

--- a/apps/web-ui/src/app/projects/[id]/page.tsx
+++ b/apps/web-ui/src/app/projects/[id]/page.tsx
@@ -459,6 +459,9 @@ export default function ProjectPage() {
           search={search}
           statusFilter={statusFilter}
           priorityFilter={priorityFilter}
+          selectedStatuses={statusFilters}
+          selectedAssignees={assigneeFilters}
+          selectedCustomFieldFilters={customFieldFilters}
         />
       ) : view === 'calendar' ? (
         <ProjectCalendarView

--- a/apps/web-ui/src/components/layout/ProjectSavedViewsControl.tsx
+++ b/apps/web-ui/src/components/layout/ProjectSavedViewsControl.tsx
@@ -3,7 +3,7 @@
 import { Bookmark, Pencil, Star, Trash2 } from 'lucide-react';
 import { type ProjectViewMode } from '@atlaspm/domain';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
@@ -53,6 +53,7 @@ export function ProjectSavedViewsControl({
   const [nameDraft, setNameDraft] = useState('');
   const [editingViewId, setEditingViewId] = useState<string | null>(null);
   const [renameDraft, setRenameDraft] = useState('');
+  const previousModeRef = useRef<SupportedProjectViewMode | null>(null);
 
   const mode = isSupportedMode(currentView) ? currentView : null;
   const selectedViewId = useMemo(
@@ -89,12 +90,13 @@ export function ProjectSavedViewsControl({
 
   useEffect(() => {
     if (!mode || (mode !== 'list' && mode !== 'board') || !savedViewsQuery.data || !listLikeWorkingState) return;
+    const modeChanged = previousModeRef.current !== null && previousModeRef.current !== mode;
 
     const resolved = resolveListLikeProjectViewState({
       mode,
       savedViews: savedViewsQuery.data,
       selectedViewId,
-      workingState: listLikeWorkingState,
+      workingState: modeChanged ? {} : listLikeWorkingState,
     });
     const nextViewId = resolved.source.namedViewId;
     const nextFilters = buildListLikeProjectViewQueryUpdates(resolved.state);
@@ -114,6 +116,10 @@ export function ProjectSavedViewsControl({
       [PROJECT_SAVED_VIEW_PARAM]: nextViewId,
     });
   }, [listLikeWorkingState, mode, savedViewsQuery.data, selectedViewId, updateProjectQueryParams]);
+
+  useEffect(() => {
+    previousModeRef.current = mode;
+  }, [mode]);
 
   const currentState = useMemo(() => {
     if (!projectId || !mode) return null;

--- a/apps/web-ui/src/components/project-alt-views.tsx
+++ b/apps/web-ui/src/components/project-alt-views.tsx
@@ -20,8 +20,9 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { api, apiBaseUrl } from '@/lib/api';
+import type { CustomFieldFilter } from '@/lib/project-filters';
 import { queryKeys } from '@/lib/query-keys';
-import type { ProjectMember, SectionTaskGroup, Task, TaskAttachment } from '@/lib/types';
+import type { CustomFieldDefinition, ProjectMember, SectionTaskGroup, Task, TaskAttachment } from '@/lib/types';
 import { useI18n } from '@/lib/i18n';
 
 function flattenTasks(groups: SectionTaskGroup[]) {
@@ -38,6 +39,38 @@ function taskMatchesFilters(
   const byStatus = statusFilter === 'ALL' || task.status === statusFilter;
   const byPriority = priorityFilter === 'ALL' || task.priority === priorityFilter;
   return bySearch && byStatus && byPriority;
+}
+
+function findTaskCustomFieldValue(task: Task, fieldId: string) {
+  return task.customFieldValues?.find((value) => value.fieldId === fieldId) ?? null;
+}
+
+function taskMatchesCustomFieldFilter(task: Task, filter: CustomFieldFilter): boolean {
+  const value = findTaskCustomFieldValue(task, filter.fieldId);
+  if (!value) return false;
+
+  if (filter.type === 'SELECT') {
+    if (!filter.optionIds?.length) return true;
+    return Boolean(value.optionId && filter.optionIds.includes(value.optionId));
+  }
+
+  if (filter.type === 'BOOLEAN') {
+    if (typeof filter.booleanValue !== 'boolean') return true;
+    return value.valueBoolean === filter.booleanValue;
+  }
+
+  if (filter.type === 'NUMBER') {
+    if (typeof value.valueNumber !== 'number') return false;
+    if (typeof filter.numberMin === 'number' && value.valueNumber < filter.numberMin) return false;
+    if (typeof filter.numberMax === 'number' && value.valueNumber > filter.numberMax) return false;
+    return true;
+  }
+
+  const valueDate = value.valueDate ? String(value.valueDate).slice(0, 10) : '';
+  if (!valueDate) return false;
+  if (filter.dateFrom && valueDate < filter.dateFrom) return false;
+  if (filter.dateTo && valueDate > filter.dateTo) return false;
+  return true;
 }
 
 function isApiConflictError(error: unknown): boolean {
@@ -150,11 +183,17 @@ export function ProjectBoardView({
   search,
   statusFilter,
   priorityFilter,
+  selectedStatuses,
+  selectedAssignees,
+  selectedCustomFieldFilters,
 }: {
   projectId: string;
   search: string;
   statusFilter: 'ALL' | Task['status'];
   priorityFilter: 'ALL' | NonNullable<Task['priority']>;
+  selectedStatuses: Task['status'][];
+  selectedAssignees: string[];
+  selectedCustomFieldFilters: CustomFieldFilter[];
 }) {
   const { t } = useI18n();
   const sensors = useSensors(useSensor(PointerSensor));
@@ -164,6 +203,10 @@ export function ProjectBoardView({
   const groupsQuery = useQuery<SectionTaskGroup[]>({
     queryKey: queryKeys.projectTasksGrouped(projectId),
     queryFn: () => api(`/projects/${projectId}/tasks?groupBy=section`),
+  });
+  const customFieldsQuery = useQuery<CustomFieldDefinition[]>({
+    queryKey: queryKeys.projectCustomFields(projectId),
+    queryFn: () => api(`/projects/${projectId}/custom-fields`),
   });
 
   const createTask = useMutation({
@@ -201,14 +244,43 @@ export function ProjectBoardView({
 
   const [draftBySection, setDraftBySection] = useState<Record<string, string>>({});
   const groups = groupsQuery.data ?? [];
+  const customFields = customFieldsQuery.data ?? [];
+  const activeCustomFieldFilters = useMemo(
+    () =>
+      selectedCustomFieldFilters.filter((filter) =>
+        customFields.some((field) => field.id === filter.fieldId && !field.archivedAt),
+      ),
+    [customFields, selectedCustomFieldFilters],
+  );
   const filteredGroups = useMemo(
     () =>
       groups.map((group) => ({
         ...group,
         sectionLabel: group.section.isDefault ? t('tasks') : group.section.name,
-        tasks: group.tasks.filter((task) => taskMatchesFilters(task, search, statusFilter, priorityFilter)),
+        tasks: group.tasks.filter((task) => {
+          const byBaseFilters = taskMatchesFilters(task, search, statusFilter, priorityFilter);
+          const bySelectedStatuses = selectedStatuses.length === 0 || selectedStatuses.includes(task.status);
+          const byAssignee =
+            selectedAssignees.length === 0 ||
+            selectedAssignees.some((assignee) =>
+              assignee === 'UNASSIGNED' ? !task.assigneeUserId : task.assigneeUserId === assignee,
+            );
+          const byCustomFields =
+            activeCustomFieldFilters.length === 0 ||
+            activeCustomFieldFilters.every((filter) => taskMatchesCustomFieldFilter(task, filter));
+          return byBaseFilters && bySelectedStatuses && byAssignee && byCustomFields;
+        }),
       })),
-    [groups, search, statusFilter, priorityFilter, t],
+    [
+      activeCustomFieldFilters,
+      groups,
+      priorityFilter,
+      search,
+      selectedAssignees,
+      selectedStatuses,
+      statusFilter,
+      t,
+    ],
   );
 
   if (groupsQuery.isLoading) {

--- a/e2e/playwright/tests/saved-views.spec.ts
+++ b/e2e/playwright/tests/saved-views.spec.ts
@@ -31,6 +31,25 @@ async function api(path: string, token: string, method = 'GET', body?: unknown) 
   return JSON.parse(raw);
 }
 
+async function createProject(page: Page, token: string, name: string) {
+  const workspaces = (await api('/workspaces', token)) as Array<{ id: string }>;
+  const workspaceId = workspaces[0]?.id;
+  if (!workspaceId) throw new Error('Workspace not found');
+
+  const project = (await api('/projects', token, 'POST', {
+    workspaceId,
+    name,
+  })) as { id: string };
+  const sections = (await api(`/projects/${project.id}/sections`, token)) as Array<{
+    id: string;
+    isDefault?: boolean;
+  }>;
+  const defaultSectionId = sections.find((section) => section.isDefault)?.id ?? sections[0]?.id;
+  if (!defaultSectionId) throw new Error('Default section not found');
+
+  return { projectId: project.id, defaultSectionId };
+}
+
 test('saved views can save and reapply a named list view without refresh', async ({ page }) => {
   const stamp = Date.now();
   const sub = `e2e-saved-views-${stamp}`;
@@ -111,4 +130,114 @@ test('saved views can save and reapply a named list view without refresh', async
   await page.click('[data-testid="saved-view-trigger"]');
   await page.locator('[data-testid^="saved-view-delete-"]').first().click();
   await expect(page.locator('[data-testid^="saved-view-apply-"]').filter({ hasText: 'Done renamed' })).toHaveCount(0);
+});
+
+test('saved views apply per-mode state when switching from a named list view to a board default', async ({ page }) => {
+  const stamp = Date.now();
+  const sub = `e2e-saved-views-modes-${stamp}`;
+  await devLogin(page, sub, `e2e-saved-views-modes-${stamp}@example.com`);
+  const token = await getToken(page);
+  const { projectId, defaultSectionId } = await createProject(page, token, `Saved Views Modes ${stamp}`);
+
+  const doneTask = (await api(`/projects/${projectId}/tasks`, token, 'POST', {
+    sectionId: defaultSectionId,
+    title: `Done Cross View ${stamp}`,
+  })) as { id: string; version: number };
+  const todoTask = (await api(`/projects/${projectId}/tasks`, token, 'POST', {
+    sectionId: defaultSectionId,
+    title: `Todo Cross View ${stamp}`,
+  })) as { id: string };
+  await api(`/tasks/${doneTask.id}`, token, 'PATCH', { status: 'DONE', version: doneTask.version });
+
+  const listView = (await api(`/projects/${projectId}/saved-views`, token, 'POST', {
+    name: 'Done only',
+    mode: 'list',
+    state: {
+      filters: {
+        statusIds: ['DONE'],
+      },
+    },
+  })) as { id: string };
+  await api(`/projects/${projectId}/saved-views/defaults/board`, token, 'PUT', {
+    state: {
+      filters: {
+        statusIds: ['IN_PROGRESS'],
+      },
+    },
+  });
+
+  await page.goto(`/projects/${projectId}?savedView=${listView.id}`);
+  await expect(page.locator(`[data-task-title="Done Cross View ${stamp}"]`)).toBeVisible();
+  await expect(page.locator(`[data-task-title="Todo Cross View ${stamp}"]`)).toHaveCount(0);
+  await page.click('[data-testid="saved-view-trigger"]');
+  await expect(page.locator('[data-testid="saved-view-active-name"]')).toContainText('Done only');
+  await page.click('[data-testid="saved-view-trigger"]');
+
+  await page.click('[data-testid="project-view-board"]');
+  await expect(page.locator(`[data-task-title="Todo Cross View ${stamp}"]`)).toBeVisible();
+  await expect(page.locator(`[data-task-title="Done Cross View ${stamp}"]`)).toHaveCount(0);
+});
+
+test('saved view fallback drops archived custom field filters on reload', async ({ page }) => {
+  const stamp = Date.now();
+  const sub = `e2e-saved-views-fallback-${stamp}`;
+  await devLogin(page, sub, `e2e-saved-views-fallback-${stamp}@example.com`);
+  const token = await getToken(page);
+  const { projectId, defaultSectionId } = await createProject(page, token, `Saved Views Fallback ${stamp}`);
+
+  const taskAlpha = (await api(`/projects/${projectId}/tasks`, token, 'POST', {
+    sectionId: defaultSectionId,
+    title: `Fallback Alpha ${stamp}`,
+  })) as { id: string; version: number };
+  const taskBeta = (await api(`/projects/${projectId}/tasks`, token, 'POST', {
+    sectionId: defaultSectionId,
+    title: `Fallback Beta ${stamp}`,
+  })) as { id: string; version: number };
+
+  const field = (await api(`/projects/${projectId}/custom-fields`, token, 'POST', {
+    name: `Fallback Stage ${stamp}`,
+    type: 'SELECT',
+    options: [
+      { label: 'Keep', value: 'keep' },
+      { label: 'Focus', value: 'focus' },
+    ],
+  })) as { id: string; options: Array<{ id: string; value: string }> };
+  const focusOptionId = field.options.find((option) => option.value === 'focus')?.id;
+  if (!focusOptionId) throw new Error('Focus option not found');
+
+  await api(`/tasks/${taskBeta.id}/custom-fields`, token, 'PATCH', {
+    version: taskBeta.version,
+    values: [{ fieldId: field.id, value: focusOptionId }],
+  });
+
+  const savedView = (await api(`/projects/${projectId}/saved-views`, token, 'POST', {
+    name: 'Focus only',
+    mode: 'list',
+    state: {
+      filters: {
+        customFieldFilters: [
+          {
+            fieldId: field.id,
+            type: 'SELECT',
+            optionIds: [focusOptionId],
+          },
+        ],
+      },
+    },
+  })) as { id: string };
+
+  await page.goto(`/projects/${projectId}?savedView=${savedView.id}`);
+  await expect(page.locator(`[data-task-title="Fallback Beta ${stamp}"]`)).toBeVisible();
+  await expect(page.locator(`[data-task-title="Fallback Alpha ${stamp}"]`)).toHaveCount(0);
+  await page.click('[data-testid="saved-view-trigger"]');
+  await expect(page.locator('[data-testid="saved-view-active-name"]')).toContainText('Focus only');
+  await page.click('[data-testid="saved-view-trigger"]');
+
+  await api(`/custom-fields/${field.id}`, token, 'DELETE');
+
+  await page.reload();
+  await expect(page.locator(`[data-task-title="Fallback Alpha ${stamp}"]`)).toBeVisible();
+  await expect(page.locator(`[data-task-title="Fallback Beta ${stamp}"]`)).toBeVisible();
+  await page.click('[data-testid="saved-view-trigger"]');
+  await expect(page.locator('[data-testid="saved-view-active-name"]')).toContainText('Focus only');
 });


### PR DESCRIPTION
## Summary
- add focused saved-view E2E coverage for named views, board default transitions, and invalid-state fallback
- sanitize stale saved-view assignee/custom-field references on read so archived or removed references fall back cleanly
- make board view consume list-like saved-view filters and reset list/board working-state precedence on mode switches

## Testing
- ./scripts/run-e2e.sh tests/saved-views.spec.ts
- pnpm --filter @atlaspm/core-api test -- core.integration.test.ts -t "saved view list sanitizes stale assignee and custom field references for fallback resolution"

Closes #273