### PR TITLE
Gate dev auth routes by environment

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -5,32 +5,39 @@
 - Branch: codex/reopen-issue-312
 - Workspace: /home/tommy/Dev/atlaspm-worktrees/issue-312
 - Journal: /home/tommy/Dev/atlaspm-worktrees/issue-312/.codex-supervisor/issue-journal.md
-- Current phase: reproducing
-- Attempt count: 1
-- Last head SHA: 9b3ec6dcc4d847200317a1a7f7c9c8fe44e02437
+- Current phase: addressing_review
+- Attempt count: 2
+- Last head SHA: 8ef726e858fe81ad7e149beee6bbfd302f62b490
 - Blocked reason: none
-- Last failure signature: none
-- Repeated failure signature count: 0
-- Updated at: 2026-03-09T10:33:19.351Z
+- Last failure signature: PRRT_kwDORWcwRc5y-9_s|PRRT_kwDORWcwRc5y--AL|PRRT_kwDORWcwRc5y--AY
+- Repeated failure signature count: 1
+- Updated at: 2026-03-09T10:45:38.448Z
 
 ## Latest Codex Summary
-- Reproduced the auth exposure issue with a focused `core-api` test that proves `DevAuthController` needs environment gating, then implemented the gating via a small dev-auth environment helper and dynamic `AuthModule.register()`.
-- Added a startup guard in `apps/core-api/src/main.ts` that throws before Nest boot when `DEV_AUTH_ENABLED=true` outside safe local/test environments.
-- Focused verification passing: `pnpm --filter @atlaspm/core-api test -- test/dev-auth-environment.test.ts` and `pnpm --filter @atlaspm/core-api type-check`.
+Addressed the three PR #316 review concerns in a focused follow-up: `AuthModule` is static again, `DevAuthController` moved into a separate optional `DevAuthModule`, missing `NODE_ENV` is now treated as unsafe, and `main.ts` preloads `.env` via `dotenv/config` before evaluating the startup guard.
+
+Focused auth-env regression coverage now also asserts the unset-`NODE_ENV` case for both route registration and fail-fast boot semantics. Local dev docs/examples were updated to require `NODE_ENV=development` when using dev auth.
+
+Summary: Resolved the three auth-env review threads by separating `DevAuthModule`, making `NODE_ENV` explicit, and loading `.env` before the startup guard.
+State hint: addressing_review
+Blocked reason: none
+Tests: `pnpm --filter @atlaspm/core-api test -- test/dev-auth-environment.test.ts`; `pnpm --filter @atlaspm/core-api type-check`
+Failure signature: none
+Next action: Commit and push the review-fix follow-up to PR #316, then resolve the bot threads.
 
 ## Active Failure Context
 - None recorded.
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: The unsafe exposure boundary is limited to `DevAuthController` registration and startup validation, so the narrowest useful regression suite is a dedicated auth-environment test rather than broader integration coverage.
-- Primary failure or risk: Route gating currently relies on `NODE_ENV` semantics; safe environments are treated as `development`, `test`, and `local`, with unset `NODE_ENV` defaulting to `development`.
+- Hypothesis: The review feedback was valid and fixable without widening scope: split the dev controller into its own optional module, require explicit safe `NODE_ENV`, and load `.env` before the guard runs.
+- Primary failure or risk: The only remaining risk is whether CI or reviewers want broader coverage than the focused auth-env suite; the reviewed issues themselves are locally addressed.
 - Last focused command: `pnpm --filter @atlaspm/core-api test -- test/dev-auth-environment.test.ts`
-- Files changed: `apps/core-api/src/auth/dev-auth-environment.ts`, `apps/core-api/src/auth/auth.module.ts`, `apps/core-api/src/app.module.ts`, `apps/core-api/src/main.ts`, `apps/core-api/test/dev-auth-environment.test.ts`
+- Files changed: `apps/core-api/src/auth/auth.module.ts`, `apps/core-api/src/auth/dev-auth.module.ts`, `apps/core-api/src/auth/dev-auth-environment.ts`, `apps/core-api/src/app.module.ts`, `apps/core-api/src/main.ts`, `apps/core-api/test/dev-auth-environment.test.ts`, `apps/core-api/.env.example`, `README.md`, `docs/startup-ubuntu.md`
 - Next 1-3 actions:
-  1. Commit the auth gating change set on `codex/reopen-issue-312`.
-  2. Optionally run one broader `core-api` integration slice if the supervisor wants extra confidence beyond the focused auth suite.
-  3. Open or update a draft PR if this branch does not already have one.
+  1. Commit and push the review-fix follow-up to PR #316.
+  2. Resolve the three configured-bot review threads with the implementation rationale.
+  3. If follow-up review requests broader coverage, run one targeted `core-api` integration slice.
 
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.
@@ -38,8 +45,15 @@
 - Focused regression coverage added in `apps/core-api/test/dev-auth-environment.test.ts`:
   - route available in `development` with `DEV_AUTH_ENABLED=true`
   - route absent in `production` even if `DEV_AUTH_ENABLED=true`
+  - route absent when `NODE_ENV` is unset
   - startup/env guard allows `test`
   - startup/env guard throws in `production`
+  - startup/env guard throws when `NODE_ENV` is unset
+- Review-fix implementation:
+  - `AuthModule` is static again to avoid duplicate module/provider instances.
+  - `DevAuthController` now lives in `DevAuthModule`, which `AppModule` imports only in safe environments.
+  - `main.ts` now preloads `.env` with `dotenv/config` before evaluating the startup guard.
+  - local docs/examples now require `NODE_ENV=development` for dev-auth usage.
 - Current focused verification passing:
   - `pnpm --filter @atlaspm/core-api test -- test/dev-auth-environment.test.ts`
   - `pnpm --filter @atlaspm/core-api type-check`

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ docker compose up -d --build
 
 - OIDC JWT verification via JWKS by default.
 - Dev auth mode is disabled by default and only enabled via `DEV_AUTH_ENABLED=true`.
+- Dev auth requires an explicit safe `NODE_ENV` (`development`, `test`, or `local`). If `NODE_ENV` is unset or unsafe, `core-api` refuses to boot with `DEV_AUTH_ENABLED=true`.
 - Risk note: when `DEV_AUTH_ENABLED=true`, `POST /dev-auth/token` is intentionally available for local testing and can mint tokens for arbitrary `sub` values.
 - `DEV_AUTH_ENABLED=true` must be treated as a critical risk outside isolated local environments.
 - Dev auth token lifetime is configurable via `DEV_AUTH_TOKEN_TTL` (default `8h`).

--- a/apps/core-api/.env.example
+++ b/apps/core-api/.env.example
@@ -1,3 +1,4 @@
+NODE_ENV=development
 PORT=3001
 DATABASE_URL=postgresql://atlaspm:atlaspm@localhost:55432/atlaspm?schema=public
 OIDC_ISSUER=https://example.okta.com/oauth2/default

--- a/apps/core-api/src/app.module.ts
+++ b/apps/core-api/src/app.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { PrismaService } from './prisma/prisma.service';
 import { AuthModule } from './auth/auth.module';
+import { DevAuthModule } from './auth/dev-auth.module';
 import { WorkspacesController } from './workspaces/workspaces.controller';
 import { ProjectsController } from './projects/projects.controller';
 import { SectionsController } from './sections/sections.controller';
@@ -35,9 +36,20 @@ import { TaskApprovalController } from './task-approvals/task-approval.controlle
 import { TaskTimeTrackingController } from './task-time-tracking/task-time-tracking.controller';
 import { ProjectRoleGuard, WorkspaceRoleGuard } from './auth/role.guard';
 import { TaskProjectLinksModule } from './task-project-links/task-project-links.module';
+import { shouldRegisterDevAuthController } from './auth/dev-auth-environment';
 
 @Module({
-  imports: [ConfigModule.forRoot({ isGlobal: true }), AuthModule.register(), SearchModule, PortfoliosModule, WorkloadModule, DashboardsModule, IntegrationsModule, TaskProjectLinksModule],
+  imports: [
+    ConfigModule.forRoot({ isGlobal: true }),
+    AuthModule,
+    ...(shouldRegisterDevAuthController() ? [DevAuthModule] : []),
+    SearchModule,
+    PortfoliosModule,
+    WorkloadModule,
+    DashboardsModule,
+    IntegrationsModule,
+    TaskProjectLinksModule,
+  ],
   controllers: [
     WorkspacesController,
     ProjectsController,

--- a/apps/core-api/src/auth/auth.module.ts
+++ b/apps/core-api/src/auth/auth.module.ts
@@ -1,19 +1,10 @@
-import { DynamicModule, Module } from '@nestjs/common';
+import { Module } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { AuthGuard } from './auth.guard';
-import { DevAuthController } from './dev-auth.controller';
 import { PrismaService } from '../prisma/prisma.service';
-import { shouldRegisterDevAuthController } from './dev-auth-environment';
 
 @Module({
   providers: [AuthService, AuthGuard, PrismaService],
   exports: [AuthService, AuthGuard, PrismaService],
 })
-export class AuthModule {
-  static register(): DynamicModule {
-    return {
-      module: AuthModule,
-      controllers: shouldRegisterDevAuthController() ? [DevAuthController] : [],
-    };
-  }
-}
+export class AuthModule {}

--- a/apps/core-api/src/auth/dev-auth-environment.ts
+++ b/apps/core-api/src/auth/dev-auth-environment.ts
@@ -1,7 +1,8 @@
 const SAFE_DEV_AUTH_NODE_ENVS = new Set(['development', 'test', 'local']);
 
 export function getDevAuthEnvironment(env: NodeJS.ProcessEnv = process.env) {
-  return (env.NODE_ENV ?? 'development').trim().toLowerCase();
+  const current = env.NODE_ENV?.trim().toLowerCase();
+  return current && current.length > 0 ? current : 'unset';
 }
 
 export function isDevAuthEnabled(env: NodeJS.ProcessEnv = process.env) {

--- a/apps/core-api/src/auth/dev-auth.module.ts
+++ b/apps/core-api/src/auth/dev-auth.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { AuthModule } from './auth.module';
+import { DevAuthController } from './dev-auth.controller';
+
+@Module({
+  imports: [AuthModule],
+  controllers: [DevAuthController],
+})
+export class DevAuthModule {}

--- a/apps/core-api/src/main.ts
+++ b/apps/core-api/src/main.ts
@@ -1,3 +1,4 @@
+import 'dotenv/config';
 import { ValidationPipe } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';

--- a/apps/core-api/test/dev-auth-environment.test.ts
+++ b/apps/core-api/test/dev-auth-environment.test.ts
@@ -1,17 +1,24 @@
 import { afterEach, describe, expect, test, vi } from 'vitest';
-import { ValidationPipe } from '@nestjs/common';
+import { Module, ValidationPipe } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
 import request from 'supertest';
 import { AuthModule } from '../src/auth/auth.module';
+import { DevAuthModule } from '../src/auth/dev-auth.module';
 import {
   assertSafeDevAuthEnvironment,
   isDevAuthEnvironmentSafe,
+  shouldRegisterDevAuthController,
 } from '../src/auth/dev-auth-environment';
 
 const originalEnv = { ...process.env };
 
 async function createApp() {
-  const moduleRef = await Test.createTestingModule({ imports: [AuthModule.register()] }).compile();
+  @Module({
+    imports: [AuthModule, ...(shouldRegisterDevAuthController() ? [DevAuthModule] : [])],
+  })
+  class TestAuthModule {}
+
+  const moduleRef = await Test.createTestingModule({ imports: [TestAuthModule] }).compile();
   const app = moduleRef.createNestApplication();
   app.useGlobalPipes(
     new ValidationPipe({ whitelist: true, transform: true, forbidNonWhitelisted: true }),
@@ -60,6 +67,22 @@ describe('dev auth environment controls', () => {
     }
   });
 
+  test('does not register /dev-auth/token when NODE_ENV is unset', async () => {
+    delete process.env.NODE_ENV;
+    process.env.DEV_AUTH_ENABLED = 'true';
+    process.env.DEV_AUTH_SECRET = 'dev-secret-change-me';
+
+    const app = await createApp();
+    try {
+      await request(app.getHttpServer())
+        .post('/dev-auth/token')
+        .send({ sub: 'unset-user' })
+        .expect(404);
+    } finally {
+      await app.close();
+    }
+  });
+
   test('treats test as a safe dev auth environment', () => {
     process.env.NODE_ENV = 'test';
     process.env.DEV_AUTH_ENABLED = 'true';
@@ -74,6 +97,15 @@ describe('dev auth environment controls', () => {
 
     expect(() => assertSafeDevAuthEnvironment()).toThrow(
       'DEV_AUTH_ENABLED=true is only allowed when NODE_ENV is one of development, test, or local; received production',
+    );
+  });
+
+  test('fails fast when dev auth is enabled and NODE_ENV is unset', () => {
+    delete process.env.NODE_ENV;
+    process.env.DEV_AUTH_ENABLED = 'true';
+
+    expect(() => assertSafeDevAuthEnvironment()).toThrow(
+      'DEV_AUTH_ENABLED=true is only allowed when NODE_ENV is one of development, test, or local; received unset',
     );
   });
 });

--- a/docs/startup-ubuntu.md
+++ b/docs/startup-ubuntu.md
@@ -61,6 +61,7 @@ cp apps/collab-server/.env.example apps/collab-server/.env
 
 For local dev login, set:
 
+- `apps/core-api/.env` -> `NODE_ENV=development`
 - `apps/core-api/.env` -> `DEV_AUTH_ENABLED=true`
 - `apps/web-ui/.env.local` -> `NEXT_PUBLIC_DEV_AUTH_ENABLED=true`
 - This setting is for isolated local development only. Do not enable it in shared or internet-reachable environments.


### PR DESCRIPTION
## Summary
- gate  registration behind safe local/test environment checks
- fail startup early when  in an unsafe environment
- add focused regression coverage for allowed and disallowed dev-auth environments

## Testing
- pnpm --filter @atlaspm/core-api test -- test/dev-auth-environment.test.ts
- pnpm --filter @atlaspm/core-api type-check