### PR TITLE
P0: Gate dev auth controller registration behind safe environment checks (#312)

### DIFF
--- a/.atlaspm-supervisor/issue-journal.md
+++ b/.atlaspm-supervisor/issue-journal.md
@@ -1,0 +1,34 @@
+# Issue #312: P0: Gate dev auth controller registration behind safe environment checks
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/atlaspm/issues/312
+- Branch: codex/issue-312
+- Workspace: /Users/tomoakikawada/Dev/atlaspm-worktrees/issue-312
+- Journal: /Users/tomoakikawada/Dev/atlaspm-worktrees/issue-312/.atlaspm-supervisor/issue-journal.md
+- Current phase: reproducing
+- Attempt count: 1
+- Last head SHA: 9b3ec6dcc4d847200317a1a7f7c9c8fe44e02437
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-03-09T10:32:41.571Z
+
+## Latest Codex Summary
+- Added a focused `dev-auth-environment` regression test that reproduced two failures: `/dev-auth/token` returned `401` instead of being absent when dev auth was off, and bootstrap did not fail when `DEV_AUTH_ENABLED=true` under `NODE_ENV=production`.
+- Fixed the boundary by moving dev auth route registration into a dedicated dynamic module, only mounting it for safe environments, and adding a startup guard that rejects unsafe `DEV_AUTH_ENABLED=true` boots.
+- Verified with the focused vitest file plus `core-api` lint and type-check.
+
+## Active Failure Context
+- None recorded.
+
+## Codex Working Notes
+- Update this section before ending each Codex turn.
+- Record the active hypothesis, the exact failing test/check, what changed, and the next 1-3 actions.
+- Keep the notes concise so future resume turns can pick up quickly.
+- Active hypothesis: dev auth exposure came from `AuthModule` mounting `DevAuthController` unconditionally; fixing registration plus a startup assertion would satisfy both route and boot criteria.
+- Exact failing test/check: `mise x node@20 -- pnpm --filter @atlaspm/core-api exec vitest run test/dev-auth-environment.test.ts` initially failed with `expected 404 "Not Found", got 401 "Unauthorized"` and `promise resolved instead of rejecting` for unsafe boot.
+- What changed: added `src/auth/dev-auth-environment.ts`, `src/auth/dev-auth-environment.guard.ts`, and `src/auth/dev-auth.module.ts`; removed `DevAuthController` from `AuthModule`; imported `DevAuthModule.register()` in `AppModule`; added focused regression tests; set `NODE_ENV=test` in core integration boot; documented `NODE_ENV=development` for local dev auth.
+- Next actions:
+- 1. Commit this checkpoint on `codex/issue-312`.
+- 2. If a DB is available next turn, run the broader `core-api` integration suite to confirm no boot regressions.
+- 3. Open/update a draft PR once broader verification is in place.

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ docker compose up -d --build
 
 - OIDC JWT verification via JWKS by default.
 - Dev auth mode is disabled by default and only enabled via `DEV_AUTH_ENABLED=true`.
+- Dev auth boot is only allowed when `NODE_ENV` is explicitly `development` or `test`.
 - Risk note: when `DEV_AUTH_ENABLED=true`, `POST /dev-auth/token` is intentionally available for local testing and can mint tokens for arbitrary `sub` values.
 - `DEV_AUTH_ENABLED=true` must be treated as a critical risk outside isolated local environments.
 - Dev auth token lifetime is configurable via `DEV_AUTH_TOKEN_TTL` (default `8h`).

--- a/apps/core-api/.env.example
+++ b/apps/core-api/.env.example
@@ -1,3 +1,4 @@
+NODE_ENV=development
 PORT=3001
 DATABASE_URL=postgresql://atlaspm:atlaspm@localhost:55432/atlaspm?schema=public
 OIDC_ISSUER=https://example.okta.com/oauth2/default

--- a/apps/core-api/src/app.module.ts
+++ b/apps/core-api/src/app.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { PrismaService } from './prisma/prisma.service';
 import { AuthModule } from './auth/auth.module';
+import { DevAuthModule } from './auth/dev-auth.module';
 import { WorkspacesController } from './workspaces/workspaces.controller';
 import { ProjectsController } from './projects/projects.controller';
 import { SectionsController } from './sections/sections.controller';
@@ -37,7 +38,17 @@ import { ProjectRoleGuard, WorkspaceRoleGuard } from './auth/role.guard';
 import { TaskProjectLinksModule } from './task-project-links/task-project-links.module';
 
 @Module({
-  imports: [ConfigModule.forRoot({ isGlobal: true }), AuthModule, SearchModule, PortfoliosModule, WorkloadModule, DashboardsModule, IntegrationsModule, TaskProjectLinksModule],
+  imports: [
+    ConfigModule.forRoot({ isGlobal: true }),
+    AuthModule,
+    DevAuthModule.register(),
+    SearchModule,
+    PortfoliosModule,
+    WorkloadModule,
+    DashboardsModule,
+    IntegrationsModule,
+    TaskProjectLinksModule,
+  ],
   controllers: [
     WorkspacesController,
     ProjectsController,

--- a/apps/core-api/src/auth/auth.module.ts
+++ b/apps/core-api/src/auth/auth.module.ts
@@ -1,12 +1,10 @@
 import { Module } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { AuthGuard } from './auth.guard';
-import { DevAuthController } from './dev-auth.controller';
 import { PrismaService } from '../prisma/prisma.service';
 
 @Module({
   providers: [AuthService, AuthGuard, PrismaService],
   exports: [AuthService, AuthGuard, PrismaService],
-  controllers: [DevAuthController],
 })
 export class AuthModule {}

--- a/apps/core-api/src/auth/dev-auth-environment.guard.ts
+++ b/apps/core-api/src/auth/dev-auth-environment.guard.ts
@@ -1,0 +1,9 @@
+import { Injectable, OnModuleInit } from '@nestjs/common';
+import { assertSafeDevAuthEnvironment } from './dev-auth-environment';
+
+@Injectable()
+export class DevAuthEnvironmentGuard implements OnModuleInit {
+  onModuleInit() {
+    assertSafeDevAuthEnvironment();
+  }
+}

--- a/apps/core-api/src/auth/dev-auth-environment.ts
+++ b/apps/core-api/src/auth/dev-auth-environment.ts
@@ -1,0 +1,30 @@
+const SAFE_DEV_AUTH_NODE_ENVS = new Set(['development', 'test']);
+
+function normalizeNodeEnv(nodeEnv: string | undefined): string | null {
+  const normalized = nodeEnv?.trim().toLowerCase();
+  return normalized ? normalized : null;
+}
+
+export function isDevAuthEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  return env.DEV_AUTH_ENABLED === 'true';
+}
+
+export function isSafeDevAuthEnvironment(env: NodeJS.ProcessEnv = process.env): boolean {
+  const nodeEnv = normalizeNodeEnv(env.NODE_ENV);
+  return nodeEnv !== null && SAFE_DEV_AUTH_NODE_ENVS.has(nodeEnv);
+}
+
+export function shouldRegisterDevAuthController(env: NodeJS.ProcessEnv = process.env): boolean {
+  return isDevAuthEnabled(env) && isSafeDevAuthEnvironment(env);
+}
+
+export function assertSafeDevAuthEnvironment(env: NodeJS.ProcessEnv = process.env): void {
+  if (!isDevAuthEnabled(env) || isSafeDevAuthEnvironment(env)) {
+    return;
+  }
+
+  const receivedNodeEnv = normalizeNodeEnv(env.NODE_ENV) ?? '(unset)';
+  throw new Error(
+    `DEV_AUTH_ENABLED=true is only allowed when NODE_ENV is one of: development, test. Received NODE_ENV=${receivedNodeEnv}.`,
+  );
+}

--- a/apps/core-api/src/auth/dev-auth.module.ts
+++ b/apps/core-api/src/auth/dev-auth.module.ts
@@ -1,0 +1,17 @@
+import { DynamicModule, Module } from '@nestjs/common';
+import { AuthModule } from './auth.module';
+import { DevAuthController } from './dev-auth.controller';
+import { shouldRegisterDevAuthController } from './dev-auth-environment';
+import { DevAuthEnvironmentGuard } from './dev-auth-environment.guard';
+
+@Module({})
+export class DevAuthModule {
+  static register(): DynamicModule {
+    return {
+      module: DevAuthModule,
+      imports: [AuthModule],
+      controllers: shouldRegisterDevAuthController() ? [DevAuthController] : [],
+      providers: [DevAuthEnvironmentGuard],
+    };
+  }
+}

--- a/apps/core-api/test/core.integration.test.ts
+++ b/apps/core-api/test/core.integration.test.ts
@@ -23,6 +23,7 @@ describe('Core API Integration', () => {
   let recurringWorker: RecurringTaskWorker;
 
   beforeAll(async () => {
+    process.env.NODE_ENV = 'test';
     process.env.DEV_AUTH_ENABLED = 'true';
     process.env.DEV_AUTH_SECRET = 'dev-secret-change-me';
     process.env.COLLAB_JWT_SECRET = 'collab-jwt-secret';

--- a/apps/core-api/test/dev-auth-environment.test.ts
+++ b/apps/core-api/test/dev-auth-environment.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, describe, expect, test } from 'vitest';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import request from 'supertest';
+import { DevAuthModule } from '../src/auth/dev-auth.module';
+import { PrismaService } from '../src/prisma/prisma.service';
+
+const ENV_KEYS = ['DEV_AUTH_ENABLED', 'DEV_AUTH_SECRET', 'NODE_ENV'] as const;
+
+function snapshotEnv(): Record<(typeof ENV_KEYS)[number], string | undefined> {
+  return {
+    DEV_AUTH_ENABLED: process.env.DEV_AUTH_ENABLED,
+    DEV_AUTH_SECRET: process.env.DEV_AUTH_SECRET,
+    NODE_ENV: process.env.NODE_ENV,
+  };
+}
+
+function restoreEnv(snapshot: Record<(typeof ENV_KEYS)[number], string | undefined>) {
+  for (const key of ENV_KEYS) {
+    const value = snapshot[key];
+    if (value === undefined) {
+      delete process.env[key];
+      continue;
+    }
+    process.env[key] = value;
+  }
+}
+
+async function createAuthApp(): Promise<INestApplication> {
+  const moduleRef = await Test.createTestingModule({ imports: [DevAuthModule.register()] })
+    .overrideProvider(PrismaService)
+    .useValue({})
+    .compile();
+
+  const app = moduleRef.createNestApplication();
+  app.useGlobalPipes(
+    new ValidationPipe({ whitelist: true, transform: true, forbidNonWhitelisted: true }),
+  );
+  return app;
+}
+
+describe('Dev auth environment guardrails', () => {
+  const envSnapshot = snapshotEnv();
+
+  afterEach(async () => {
+    restoreEnv(envSnapshot);
+  });
+
+  test('does not mount /dev-auth/token when dev auth is disabled', async () => {
+    process.env.NODE_ENV = 'test';
+    process.env.DEV_AUTH_ENABLED = 'false';
+
+    const app = await createAuthApp();
+    await app.init();
+
+    try {
+      await request(app.getHttpServer()).post('/dev-auth/token').send({ sub: 'user-123' }).expect(404);
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('fails startup when dev auth is enabled in an unsafe environment', async () => {
+    process.env.NODE_ENV = 'production';
+    process.env.DEV_AUTH_ENABLED = 'true';
+    process.env.DEV_AUTH_SECRET = 'dev-secret';
+
+    const app = await createAuthApp();
+
+    await expect(app.init()).rejects.toThrow(/DEV_AUTH_ENABLED=true is only allowed/i);
+  });
+
+  test('allows dev auth token minting in the test environment', async () => {
+    process.env.NODE_ENV = 'test';
+    process.env.DEV_AUTH_ENABLED = 'true';
+    process.env.DEV_AUTH_SECRET = 'dev-secret';
+
+    const app = await createAuthApp();
+    await app.init();
+
+    try {
+      const response = await request(app.getHttpServer())
+        .post('/dev-auth/token')
+        .send({ sub: 'user-123', email: 'user@example.com', name: 'User Example' })
+        .expect(201);
+
+      expect(typeof response.body.token).toBe('string');
+      expect(response.body.token.length).toBeGreaterThan(20);
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/docs/startup-ubuntu.md
+++ b/docs/startup-ubuntu.md
@@ -61,6 +61,7 @@ cp apps/collab-server/.env.example apps/collab-server/.env
 
 For local dev login, set:
 
+- `apps/core-api/.env` -> `NODE_ENV=development`
 - `apps/core-api/.env` -> `DEV_AUTH_ENABLED=true`
 - `apps/web-ui/.env.local` -> `NEXT_PUBLIC_DEV_AUTH_ENABLED=true`
 - This setting is for isolated local development only. Do not enable it in shared or internet-reachable environments.


### PR DESCRIPTION
Closes #312
This PR was opened by atlaspm-supervisor.
Latest Codex summary:

Dev auth is now gated behind explicit safe env checks. I moved dev token routing into a dedicated dynamic module so `/dev-auth/token` is only registered when `DEV_AUTH_ENABLED=true` and `NODE_ENV` is `development` or `test`, and added a startup guard that throws on unsafe boots. The main wiring is in [app.module.ts](/Users/tomoakikawada/Dev/atlaspm-worktrees/issue-312/apps/core-api/src/app.module.ts#L40), with the env policy in [dev-auth-environment.ts](/Users/tomoakikawada/Dev/atlaspm-worktrees/issue-312/apps/core-api/src/auth/dev-auth-environment.ts#L1), module registration in [dev-auth.module.ts](/Users/tomoakikawada/Dev/atlaspm-worktrees/issue-312/apps/core-api/src/auth/dev-auth.module.ts#L1), and the boot-time guard in [dev-auth-environment.guard.ts](/Users/tomoakikawada/Dev/atlaspm-worktrees/issue-312/apps/core-api/src/auth/dev-auth-environment.guard.ts#L1).

I added a focused regression file at [dev-auth-environment.test.ts](/Users/tomoakikawada/Dev/atlaspm-worktrees/issue-312/apps/core-api/test/dev-auth-environment.test.ts#L1) that reproduces the original bug and now passes for disabled, allowed, and unsafe env cases. I also set `NODE_ENV=test` explicitly in [core.integration.test.ts](/Users/tomoakikawada/Dev/atlaspm-worktrees/issue-312/apps/core-api/test/core.integration.test.ts#L25) and documented the local-dev requirement in [README.md](/Users/tomoakikawada/Dev/atlaspm-worktrees/issue-312/README.md#L91), [apps/core-api/.env.example](/Users/tomoakikawada/Dev/atla...