### PR TITLE
P4: Add regression coverage for integration auth and sync behavior (#371)

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -5,53 +5,61 @@
 - Branch: codex/reopen-issue-371
 - Workspace: /home/tommy/Dev/atlaspm-worktrees/issue-371
 - Journal: /home/tommy/Dev/atlaspm-worktrees/issue-371/.codex-supervisor/issue-journal.md
-- Current phase: reproducing
-- Attempt count: 1
-- Last head SHA: 6c9fbedeaaf35c83a73f59d3b41e73e92b01186f
+- Current phase: addressing_review
+- Attempt count: 2
+- Last head SHA: 94252b34eea187b0c08fb064fd42af25fb08050d
 - Blocked reason: none
-- Last failure signature: none
-- Repeated failure signature count: 0
-- Updated at: 2026-03-11T03:32:28.825Z
+- Last failure signature: PRRT_kwDORWcwRc5zehc_|PRRT_kwDORWcwRc5zehdM|PRRT_kwDORWcwRc5zehdY
+- Repeated failure signature count: 1
+- Updated at: 2026-03-11T03:41:22.467Z
 
 ## Latest Codex Summary
-- None yet.
+Added a focused regression slice for sync failure observability. The new GitHub integration test in [github-issues.integration.test.ts](/home/tommy/Dev/atlaspm-worktrees/issue-371/apps/core-api/test/github-issues.integration.test.ts) now forces an upstream `500` and proves the API persists a sanitized `FAILED` sync state plus matching `integration.sync.failed` audit/outbox records. To make that pass, [integrations.service.ts](/home/tommy/Dev/atlaspm-worktrees/issue-371/apps/core-api/src/integrations/integrations.service.ts) now catches runtime sync failures, records failure observability, and rethrows.
+
+Focused verification passed after bringing the worktree to a runnable baseline with `pnpm install`, Prisma generate, and a build of `@atlaspm/domain`. I also updated the supervisor notes in [issue-journal.md](/home/tommy/Dev/atlaspm-worktrees/issue-371/.codex-supervisor/issue-journal.md) and checkpointed the work as commit `94252b3` (`Add sync failure observability regression coverage`).
+
+Summary: Added focused GitHub sync-failure regression coverage and implemented missing `integration.sync.failed` audit/outbox emission.
+State hint: stabilizing
+Blocked reason: none
+Tests: `pnpm install`; `pnpm --filter @atlaspm/core-api prisma:generate`; `pnpm --filter @atlaspm/domain build`; `pnpm --filter @atlaspm/core-api exec vitest run test/github-issues.integration.test.ts`; `pnpm --filter @atlaspm/core-api exec vitest run test/github-issues.integration.test.ts test/integration-runtime.service.test.ts test/integration-credentials.service.test.ts test/integration-provider.registry.test.ts test/integration-contracts.test.ts`; `pnpm --filter @atlaspm/core-api lint`; `pnpm --filter @atlaspm/core-api type-check`; `git diff --check`
+Failure signature: none
+Next action: Extend the reference-provider coverage with retry and partial-sync regression tests on top of this new failure-path baseline
 
 ## Active Failure Context
-- None recorded.
+- Category: review
+- Summary: 3 unresolved automated review thread(s) remain.
+- Reference: https://github.com/TommyKammy/atlaspm/pull/378#discussion_r2915670853
+- Details:
+  - apps/core-api/src/integrations/integrations.service.ts:140 `result` is declared without a type/initializer, so it becomes `any` and weakens type-safety for the rest of `triggerSync` (e.g., `result.status`, `importedCount`). Consider typing it as `RunIntegrationSyncJobResult` (or the runtime return type) and/or initializing it inside the `try` to keep inference.
+  - apps/core-api/test/github-issues.integration.test.ts:476 `failIssueSyncMessage` is mutable shared state across the whole test file (captured by the mock GitHub server). If an assertion throws before the reset, later tests can unexpectedly keep returning 500s. Consider resetting it in a `finally` block around the sync call (or in `afterEach`) to avoid cross-test contamination. ```suggestion let syncRes; try { syncRes = await request(app.getHttpServer()) .post(`/workspaces/${workspaceId}/integrations/${connectRes.body.id}/sync`) .set('Authorization', `Bearer ${token}`) .send({ scope: 'issues' }) .expect(500); expect(syncRes.body.message).toBe('Internal server error'); const syncState = await prisma.integrationSyncState.findUnique({ where: { providerConfigId_scope: { providerConfigId: connectRes.body.id as string, scope: 'issues', }, }, }); expect(syncState?.status).toBe('FAILED'); expect(syncState?.lastErrorCode).toBe('INTEGRATION_SYNC_FAILED'); expect(syncState?.lastErrorMessage).toBe('GitHub API request failed with status 500'); expect(syncState?.finishedAt).not.toBeNull(); const auditEvents = await prisma.auditEvent.findMany({ where: { entityId: connectRes.body.id as string, action: 'integration.sync.failed', }, }); expect(auditEvents).toHaveLength(1); expect(auditEvents[0]?.afterJson).toMatchObject({ scope: 'issues', status: 'failed', errorCode: 'INTEGRATION_SYNC_FAILED', errorMessage: 'GitHub API request failed with status 500', }); const outboxEvents = await prisma.outboxEvent.findMany({ where: { type: 'integration.sync.failed', payload: { path: ['providerConfigId'], equals: connectRes.body.id as string, }, }, }); expect(outboxEvents).toHaveLength(1); expect(outboxEvents[0]?.payload).toMatchObject({ providerConfigId: connectRes.body.id, workspaceId, scope: 'issues', errorCode: 'INTEGRATION_SYNC_FAILED', errorMessage: 'GitHub API request failed with status 500', }); } finally { failIssueSyncMessage = null; } ```
+  - apps/core-api/test/github-issues.integration.test.ts:432 This assertion relies on Nest's default 500 response shape (`{ message: 'Internal server error' }`), but the production app installs `GlobalErrorFilter`, which returns `{ error: { message: ... } }`. To keep the regression test aligned with production (and more future-proof), consider applying `GlobalErrorFilter` in this suite and asserting against the filtered shape (or only asserting on status code here). ```suggestion ```
 
 ## Codex Working Notes
-### 2026-03-11 Codex Sync Failure Observability Coverage
+### 2026-03-11 Codex Review Fixes for PR #378
 - Hypothesis:
-  - The GitHub reference-provider flow covered connect and happy-path sync, but it did not lock in failure observability for sync execution.
-- Focused reproduction:
-  - Expanded `apps/core-api/test/github-issues.integration.test.ts` with a mocked upstream `500` on the issues endpoint.
-  - First focused run: `pnpm --filter @atlaspm/core-api exec vitest run test/github-issues.integration.test.ts`
-  - Initial environment failures in this worktree:
-    - `Command "vitest" not found` before `pnpm install`
-    - missing Prisma client before `pnpm --filter @atlaspm/core-api prisma:generate`
-    - unresolved `@atlaspm/domain` entry before `pnpm --filter @atlaspm/domain build`
-  - Behavioral repro after environment setup:
-    - The new test showed `IntegrationRuntimeService` already persisted a sanitized `FAILED` sync state, but `IntegrationsService.triggerSync()` emitted no `integration.sync.failed` audit or outbox record.
-- Implementation:
-  - Updated `apps/core-api/src/integrations/integrations.service.ts` to catch runtime sync failures, serialize the sanitized error, append `integration.sync.failed` audit/outbox records, and rethrow the original error.
-  - Added API-level regression coverage in `apps/core-api/test/github-issues.integration.test.ts` for failed sync state persistence plus failure audit/outbox observability.
+  - All three configured-bot review comments on the new sync-failure regression slice were valid and could be fixed without changing behavior.
+- Review items addressed:
+  - `apps/core-api/src/integrations/integrations.service.ts`
+    - Typed `result` in `triggerSync()` as `RunIntegrationSyncJobResult` instead of leaving it implicitly `any`.
+  - `apps/core-api/test/github-issues.integration.test.ts`
+    - Wrapped the forced failing sync request in a `try`/`finally` so `failIssueSyncMessage` is always reset, even if an assertion fails.
+    - Dropped the brittle assertion on Nest's default `500` body shape and kept the regression focused on status code plus persisted/audited failure state.
 - Verification:
-  - `pnpm install`
-  - `pnpm --filter @atlaspm/core-api prisma:generate`
-  - `pnpm --filter @atlaspm/domain build`
-  - `pnpm --filter @atlaspm/core-api exec vitest run test/github-issues.integration.test.ts` (failed first on missing failure audit/outbox)
   - `pnpm --filter @atlaspm/core-api exec vitest run test/github-issues.integration.test.ts`
-  - `pnpm --filter @atlaspm/core-api exec vitest run test/github-issues.integration.test.ts test/integration-runtime.service.test.ts test/integration-credentials.service.test.ts test/integration-provider.registry.test.ts test/integration-contracts.test.ts`
   - `pnpm --filter @atlaspm/core-api lint`
   - `pnpm --filter @atlaspm/core-api type-check`
   - `git diff --check`
 - Current outcome:
-  - Failed manual sync attempts now leave behind both sanitized sync-state persistence and matching audit/outbox observability records.
-  - The GitHub reference-provider integration suite now guards the failure path alongside connect, duplicate-key, and auth-cleanup behavior.
+  - The review threads are addressed without widening the runtime behavior surface.
+  - The GitHub failure-path regression no longer depends on test-order-sensitive mutable state or framework-specific default error serialization.
 - Failure signature:
-  - `missing-integration-sync-failure-audit`
+  - `PRRT_kwDORWcwRc5zehc_|PRRT_kwDORWcwRc5zehdM|PRRT_kwDORWcwRc5zehdY`
 - Next actions:
-  - Extend the reference-provider suite with retry/partial-sync coverage on top of this failure-path baseline.
+  - Commit, push, and resolve the three review threads on PR #378.
+
+### Current Handoff
+- Older scratchpad entries were compacted by codex-supervisor to keep resume context small.
+
 
 ### Current Handoff
 - Older scratchpad entries were compacted by codex-supervisor to keep resume context small.

--- a/apps/core-api/src/integrations/integrations.service.ts
+++ b/apps/core-api/src/integrations/integrations.service.ts
@@ -8,7 +8,7 @@ import {
 import { IntegrationCredentialKind, IntegrationProviderKind, WorkspaceRole } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 import { DomainService } from '../common/domain.service';
-import { IntegrationRuntimeService } from './integration-runtime.service';
+import { IntegrationRuntimeService, type RunIntegrationSyncJobResult } from './integration-runtime.service';
 import { IntegrationCredentialsService } from './integration-credentials.service';
 import { Prisma } from '@prisma/client';
 import { GithubProviderSettings } from './github.types';
@@ -127,7 +127,7 @@ export class IntegrationsService {
     await this.domain.requireWorkspaceRole(input.workspaceId, input.actorUserId, WorkspaceRole.WS_ADMIN);
     const config = await this.getConfigOrThrow(input.providerConfigId, input.workspaceId);
     const providerKey = this.mapProviderKey(config.provider);
-    let result;
+    let result: RunIntegrationSyncJobResult;
 
     try {
       result = await this.runtime.runSyncJob({

--- a/apps/core-api/test/github-issues.integration.test.ts
+++ b/apps/core-api/test/github-issues.integration.test.ts
@@ -420,15 +420,15 @@ describe('GitHub issues integration', () => {
 
     failIssueSyncMessage = 'upstream token secret=ghp_super_secret_token';
 
-    const syncRes = await request(app.getHttpServer())
-      .post(`/workspaces/${workspaceId}/integrations/${connectRes.body.id}/sync`)
-      .set('Authorization', `Bearer ${token}`)
-      .send({ scope: 'issues' })
-      .expect(500);
-
-    failIssueSyncMessage = null;
-
-    expect(syncRes.body.message).toBe('Internal server error');
+    try {
+      await request(app.getHttpServer())
+        .post(`/workspaces/${workspaceId}/integrations/${connectRes.body.id}/sync`)
+        .set('Authorization', `Bearer ${token}`)
+        .send({ scope: 'issues' })
+        .expect(500);
+    } finally {
+      failIssueSyncMessage = null;
+    }
 
     const syncState = await prisma.integrationSyncState.findUnique({
       where: {


### PR DESCRIPTION
Closes #371
This PR was opened by codex-supervisor.
Latest Codex summary:

Added a focused regression slice for sync failure observability. The new GitHub integration test in [github-issues.integration.test.ts](/home/tommy/Dev/atlaspm-worktrees/issue-371/apps/core-api/test/github-issues.integration.test.ts) now forces an upstream `500` and proves the API persists a sanitized `FAILED` sync state plus matching `integration.sync.failed` audit/outbox records. To make that pass, [integrations.service.ts](/home/tommy/Dev/atlaspm-worktrees/issue-371/apps/core-api/src/integrations/integrations.service.ts) now catches runtime sync failures, records failure observability, and rethrows.

Focused verification passed after bringing the worktree to a runnable baseline with `pnpm install`, Prisma generate, and a build of `@atlaspm/domain`. I also updated the supervisor notes in [issue-journal.md](/home/tommy/Dev/atlaspm-worktrees/issue-371/.codex-supervisor/issue-journal.md) and checkpointed the work as commit `94252b3` (`Add sync failure observability regression coverage`).

Summary: Added focused GitHub sync-failure regression coverage and implemented missing `integration.sync.failed` audit/outbox emission.
State hint: stabilizing
Blocked reason: none
Tests: `pnpm install`; `pnpm --filter @atlaspm/core-api prisma:generate`; `pnpm --filter @atlaspm/domain build`; `pnpm --filter @atlaspm/core-api exec vitest run test/github-issues.integration.test.ts`; `pnpm --filter @atlaspm/core-api exec vitest run test/github-issues.integration.test.ts test/integration-runti...