### PR TITLE
P3: Add regression coverage for capacity-aware workload planning

### DIFF
--- a/apps/web-ui/src/app/workspaces/[workspaceId]/workload/page.tsx
+++ b/apps/web-ui/src/app/workspaces/[workspaceId]/workload/page.tsx
@@ -221,7 +221,7 @@ function UserWorkloadCard({
     );
 
     return (
-      <Card>
+      <Card data-testid={`workload-card-${workload.userId}`}>
         <CardHeader>
           <div className="flex items-start justify-between">
             <div>
@@ -328,7 +328,7 @@ function UserWorkloadCard({
     const maxTasks = Math.max(...visibleWeeks.map((w) => Math.max(w.taskCount, w.capacityTasks)), CAPACITY_TASKS);
 
     return (
-      <Card>
+      <Card data-testid={`workload-card-${workload.userId}`}>
         <CardHeader>
           <div className="flex items-start justify-between">
             <div>

--- a/e2e/playwright/tests/workload.spec.ts
+++ b/e2e/playwright/tests/workload.spec.ts
@@ -29,6 +29,10 @@ async function api(path: string, token: string, method = 'GET', body?: unknown) 
   return res.json();
 }
 
+function workloadCard(page: Page, userId: string) {
+  return page.getByTestId(`workload-card-${userId}`);
+}
+
 async function inviteAndAcceptWorkspaceMember(
   ownerToken: string,
   workspaceId: string,
@@ -134,7 +138,7 @@ async function createCapacityScenario(browser: Browser) {
   }
 
   const reducedTask = (await api(`/projects/${project.id}/tasks`, ownerToken, 'POST', {
-    title: `Reduced capacity ${stamp}`,
+    title: `Lower capacity ${stamp}`,
     assigneeUserId: reducedSub,
     dueAt,
   })) as { id: string };
@@ -145,9 +149,12 @@ async function createCapacityScenario(browser: Browser) {
     ownerPage,
     workspaceId,
     ownerEmail,
+    ownerSub,
+    overloadedSub,
     overloadedContext,
     overloadedPage,
     overloadedEmail,
+    reducedSub,
     reducedContext,
     reducedPage,
     reducedEmail,
@@ -197,39 +204,44 @@ test('workload page shows capacity-aware indicators, filters, and reload state',
     workspaceId,
     overloadedEmail,
     reducedEmail,
+    overloadedSub,
+    reducedSub,
     overloadedContext,
     reducedContext,
   } = await createCapacityScenario(browser);
 
   try {
+    const overloadedCard = workloadCard(ownerPage, overloadedSub);
+    const reducedCard = workloadCard(ownerPage, reducedSub);
+
     await ownerPage.goto(`/workspaces/${workspaceId}/workload`);
 
     await expect(ownerPage.locator(`text=${overloadedEmail}`)).toBeVisible();
     await expect(ownerPage.locator(`text=${reducedEmail}`)).toBeVisible();
-    await expect(ownerPage.locator('text=+1 over capacity')).toBeVisible();
-    await expect(ownerPage.locator('text=Reduced capacity')).toBeVisible();
-    await expect(ownerPage.locator('text=2 task capacity')).toBeVisible();
+    await expect(overloadedCard.getByText('+1 over capacity', { exact: true })).toBeVisible();
+    await expect(reducedCard.getByText('Reduced capacity', { exact: true })).toBeVisible();
+    await expect(reducedCard.getByText('2 task capacity', { exact: true })).toBeVisible();
 
     await ownerPage.reload();
     await expect(ownerPage.locator(`text=${overloadedEmail}`)).toBeVisible();
     await expect(ownerPage.locator(`text=${reducedEmail}`)).toBeVisible();
-    await expect(ownerPage.locator('text=+1 over capacity')).toBeVisible();
-    await expect(ownerPage.locator('text=Reduced capacity')).toBeVisible();
+    await expect(overloadedCard.getByText('+1 over capacity', { exact: true })).toBeVisible();
+    await expect(reducedCard.getByText('Reduced capacity', { exact: true })).toBeVisible();
 
     await ownerPage.getByRole('button', { name: 'Effort View' }).click();
-    await expect(ownerPage.locator('text=+1h over capacity')).toBeVisible();
-    await expect(ownerPage.locator('text=5h / 6h')).toBeVisible();
+    await expect(overloadedCard.getByText('+1h over capacity', { exact: true })).toBeVisible();
+    await expect(reducedCard.getByText('5h / 6h', { exact: true })).toBeVisible();
 
     await ownerPage.getByRole('button', { name: /All people \(/ }).click();
-    await ownerPage.getByRole('option', { name: /Over capacity \(/ }).click();
+    await ownerPage.getByRole('button', { name: /Over capacity \(/ }).click();
     await expect(ownerPage.locator(`text=${overloadedEmail}`)).toBeVisible();
     await expect(ownerPage.locator(`text=${reducedEmail}`)).toHaveCount(0);
 
     await ownerPage.getByRole('button', { name: /Over capacity \(/ }).click();
-    await ownerPage.getByRole('option', { name: /Reduced capacity \(/ }).click();
+    await ownerPage.getByRole('button', { name: /Reduced capacity \(/ }).click();
     await expect(ownerPage.locator(`text=${reducedEmail}`)).toBeVisible();
     await expect(ownerPage.locator(`text=${overloadedEmail}`)).toHaveCount(0);
-    await expect(ownerPage.locator('text=5h / 6h')).toBeVisible();
+    await expect(reducedCard.getByText('5h / 6h', { exact: true })).toBeVisible();
   } finally {
     await reducedContext.close();
     await overloadedContext.close();
@@ -245,17 +257,24 @@ test('non-admin team members only see their own workload cards', async ({ browse
     reducedPage,
     workspaceId,
     ownerEmail,
+    ownerSub,
     overloadedEmail,
+    overloadedSub,
     reducedEmail,
+    reducedSub,
   } = await createCapacityScenario(browser);
 
   try {
+    const reducedCard = workloadCard(reducedPage, reducedSub);
+
     await reducedPage.goto(`/workspaces/${workspaceId}/workload`);
 
     await expect(reducedPage.locator(`text=${reducedEmail}`)).toBeVisible();
     await expect(reducedPage.locator(`text=${overloadedEmail}`)).toHaveCount(0);
     await expect(reducedPage.locator(`text=${ownerEmail}`)).toHaveCount(0);
-    await expect(reducedPage.locator('text=Reduced capacity')).toBeVisible();
+    await expect(reducedPage.locator(`text=${ownerSub}@example.com`)).toHaveCount(0);
+    await expect(reducedPage.locator(`text=${overloadedSub}@example.com`)).toHaveCount(0);
+    await expect(reducedCard.getByText('Reduced capacity', { exact: true })).toBeVisible();
 
     await reducedPage.reload();
     await expect(reducedPage.locator(`text=${reducedEmail}`)).toBeVisible();


### PR DESCRIPTION
## Summary
- add card-scoped workload selectors for capacity-aware workload assertions
- cover workload over-capacity, reduced-capacity, reload, and permission boundaries in Playwright
- keep capacity schedule and time-off integration coverage green while stabilizing the workload E2E flow

## Testing
- pnpm --filter @atlaspm/web-ui test -- src/app/workspaces/[workspaceId]/workload/workload-helpers.test.ts
- pnpm --filter @atlaspm/core-api test -- test/capacity.integration.test.ts
- pnpm --filter @atlaspm/web-ui type-check
- git diff --check
- pnpm --filter @atlaspm/playwright exec playwright test tests/workload.spec.ts --reporter=list

Closes #366