### PR TITLE
[codex] Break domain service into focused core services

### DIFF
--- a/.atlaspm-supervisor/issue-journal.md
+++ b/.atlaspm-supervisor/issue-journal.md
@@ -3,8 +3,8 @@
 ## Supervisor Snapshot
 - Issue URL: https://github.com/TommyKammy/atlaspm/issues/312
 - Branch: codex/issue-312
-- Workspace: /Users/tomoakikawada/Dev/atlaspm-worktrees/issue-312
-- Journal: /Users/tomoakikawada/Dev/atlaspm-worktrees/issue-312/.atlaspm-supervisor/issue-journal.md
+- Workspace: atlaspm-worktree/issue-312
+- Journal: atlaspm-worktree/issue-312/.atlaspm-supervisor/issue-journal.md
 - Current phase: reproducing
 - Attempt count: 1
 - Last head SHA: 9b3ec6dcc4d847200317a1a7f7c9c8fe44e02437

--- a/.atlaspm-supervisor/issue-journal.md
+++ b/.atlaspm-supervisor/issue-journal.md
@@ -3,8 +3,8 @@
 ## Supervisor Snapshot
 - Issue URL: https://github.com/TommyKammy/atlaspm/issues/312
 - Branch: codex/issue-312
-- Workspace: atlaspm-worktree/issue-312
-- Journal: atlaspm-worktree/issue-312/.atlaspm-supervisor/issue-journal.md
+- Workspace: /Users/tomoakikawada/Dev/atlaspm-worktrees/issue-312
+- Journal: /Users/tomoakikawada/Dev/atlaspm-worktrees/issue-312/.atlaspm-supervisor/issue-journal.md
 - Current phase: reproducing
 - Attempt count: 1
 - Last head SHA: 9b3ec6dcc4d847200317a1a7f7c9c8fe44e02437

--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -3,8 +3,8 @@
 ## Supervisor Snapshot
 - Issue URL: https://github.com/TommyKammy/atlaspm/issues/384
 - Branch: codex/reopen-issue-384
-- Workspace: /home/tommy/Dev/atlaspm-worktrees/issue-384
-- Journal: /home/tommy/Dev/atlaspm-worktrees/issue-384/.codex-supervisor/issue-journal.md
+- Workspace: <redacted-local-path>
+- Journal: <redacted-local-path>
 - Current phase: reproducing
 - Attempt count: 1
 - Last head SHA: 3f0dd1fad770877fea51ee37ed8788bd2899d42b

--- a/.codex-supervisor/issues/391/issue-journal.md
+++ b/.codex-supervisor/issues/391/issue-journal.md
@@ -1,0 +1,33 @@
+# Issue #391: P0: Break domain service into focused core services
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/atlaspm/issues/391
+- Branch: codex/issue-391
+- Workspace: .
+- Journal: .codex-supervisor/issues/391/issue-journal.md
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: 2e1253bfef1ca7d322f3cb688cdcc05669d6992a
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-15T09:26:57.123Z
+
+## Latest Codex Summary
+- Added focused tests for extracted authorization/default-workspace behavior, introduced focused common services (`AuthorizationService`, `AuditOutboxService`, `IdentityService`, `WorkspaceDefaultsService`), and trimmed `DomainService` to pure helpers plus a temporary delegating facade while migrations continue.
+
+## Active Failure Context
+- None recorded.
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: The safest path is to pin one narrow behavior first, extract service ownership, then migrate consumers in batches while leaving a thin `DomainService` facade until the last call sites are moved.
+- What changed: Added `domain.default-workspace.service.test.ts`; moved auth/membership, audit/outbox, identity sync, and default-workspace/project-default logic into dedicated services under `apps/core-api/src/common/`; added `CommonServicesModule`; migrated `AuthGuard`, `ProjectRoleGuard`, `WorkspaceRoleGuard`, `AuditController`, `WorkspacesController`, and `ProjectsController` to direct focused services; updated the guest-authorization test to target `AuthorizationService`.
+- Current blocker: No hard blocker. Remaining work is broad consumer migration off the temporary `DomainService` facade.
+- Next exact step: Migrate the next high-volume controller/service buckets (`rules`, `tasks`, task adjunct services, workspace admin, integrations/goals/capacity/workload) to inject `AuthorizationService` and/or `AuditOutboxService` directly, then remove the delegating methods from `DomainService`.
+- Verification gap: Full `lint` and full `core-api test` suite have not been run yet; only focused tests plus `type-check` were executed after the extraction scaffold.
+- Files touched: `apps/core-api/src/common/*`, `apps/core-api/src/auth/auth.guard.ts`, `apps/core-api/src/auth/role.guard.ts`, `apps/core-api/src/auth/auth.module.ts`, `apps/core-api/src/app.module.ts`, `apps/core-api/src/audit/audit.controller.ts`, `apps/core-api/src/workspaces/workspaces.controller.ts`, `apps/core-api/src/projects/projects.controller.ts`, module files for portfolios/goals/integrations/capacity/workload/task-project-links, and focused tests in `apps/core-api/test/`.
+- Rollback concern: `DomainService` is currently a compatibility facade over the new services; removing it too early without migrating remaining consumers will break compile-time contracts.
+- Last focused command: `pnpm --filter @atlaspm/core-api type-check`
+### Scratchpad
+- Keep this section short. The supervisor may compact older notes automatically.

--- a/apps/core-api/src/app.module.ts
+++ b/apps/core-api/src/app.module.ts
@@ -9,7 +9,6 @@ import { TasksController } from './tasks/tasks.controller';
 import { RulesController } from './rules/rules.controller';
 import { WebhooksController } from './webhooks/webhooks.controller';
 import { AuditController } from './audit/audit.controller';
-import { DomainService } from './common/domain.service';
 import { SubtaskService } from './tasks/subtask.service';
 import { CycleDetectionService } from './tasks/cycle-detection.service';
 import { ReminderDeliveryService } from './tasks/reminder-delivery.service';

--- a/apps/core-api/src/app.module.ts
+++ b/apps/core-api/src/app.module.ts
@@ -1,6 +1,5 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
-import { PrismaService } from './prisma/prisma.service';
 import { AuthModule } from './auth/auth.module';
 import { DevAuthModule } from './auth/dev-auth.module';
 import { WorkspacesController } from './workspaces/workspaces.controller';
@@ -50,10 +49,12 @@ import { TaskRemindersService } from './tasks/task-reminders.service';
 import { GoalsModule } from './goals/goals.module';
 import { CapacityModule } from './capacity/capacity.module';
 import { GuestAccessController } from './guest-access/guest-access.controller';
+import { CommonServicesModule } from './common/common-services.module';
 
 @Module({
   imports: [
     ConfigModule.forRoot({ isGlobal: true }),
+    CommonServicesModule,
     ApiThrottlingModule,
     AuthModule,
     DevAuthModule.register(),
@@ -92,8 +93,6 @@ import { GuestAccessController } from './guest-access/guest-access.controller';
     GuestAccessController,
   ],
   providers: [
-    PrismaService,
-    DomainService,
     SubtaskService,
     CycleDetectionService,
     ReminderDeliveryService,

--- a/apps/core-api/src/audit/audit.controller.ts
+++ b/apps/core-api/src/audit/audit.controller.ts
@@ -1,7 +1,7 @@
 import { BadRequestException, Controller, Get, Inject, Param, Query, UseGuards } from '@nestjs/common';
 import { AuthGuard } from '../auth/auth.guard';
 import { PrismaService } from '../prisma/prisma.service';
-import { DomainService } from '../common/domain.service';
+import { AuthorizationService } from '../common/authorization.service';
 import { CurrentRequest } from '../common/current-request';
 import type { AppRequest } from '../common/types';
 import { ProjectRole } from '@prisma/client';
@@ -11,19 +11,19 @@ import { ProjectRole } from '@prisma/client';
 export class AuditController {
   constructor(
     @Inject(PrismaService) private readonly prisma: PrismaService,
-    @Inject(DomainService) private readonly domain: DomainService,
+    @Inject(AuthorizationService) private readonly authorization: AuthorizationService,
   ) {}
 
   @Get('tasks/:id/audit')
   async taskAudit(@Param('id') taskId: string, @CurrentRequest() req: AppRequest) {
     const task = await this.prisma.task.findUniqueOrThrow({ where: { id: taskId } });
-    await this.domain.requireProjectRole(task.projectId, req.user.sub, ProjectRole.VIEWER);
+    await this.authorization.requireProjectRole(task.projectId, req.user.sub, ProjectRole.VIEWER);
     return this.prisma.auditEvent.findMany({ where: { entityType: 'Task', entityId: taskId }, orderBy: { createdAt: 'desc' } });
   }
 
   @Get('projects/:id/audit')
   async projectAudit(@Param('id') projectId: string, @CurrentRequest() req: AppRequest) {
-    await this.domain.requireProjectRole(projectId, req.user.sub, ProjectRole.VIEWER);
+    await this.authorization.requireProjectRole(projectId, req.user.sub, ProjectRole.VIEWER);
     return this.prisma.auditEvent.findMany({
       where: {
         OR: [
@@ -52,7 +52,7 @@ export class AuditController {
   @Get('sections/:id/audit')
   async sectionAudit(@Param('id') sectionId: string, @CurrentRequest() req: AppRequest) {
     const section = await this.prisma.section.findUniqueOrThrow({ where: { id: sectionId } });
-    await this.domain.requireProjectRole(section.projectId, req.user.sub, ProjectRole.VIEWER);
+    await this.authorization.requireProjectRole(section.projectId, req.user.sub, ProjectRole.VIEWER);
     return this.prisma.auditEvent.findMany({ where: { entityType: 'Section', entityId: sectionId }, orderBy: { createdAt: 'desc' } });
   }
 
@@ -62,7 +62,7 @@ export class AuditController {
     @Query('projectId') projectId?: string,
   ) {
     if (!projectId) throw new BadRequestException('projectId is required');
-    await this.domain.requireProjectRole(projectId, req.user.sub, ProjectRole.VIEWER);
+    await this.authorization.requireProjectRole(projectId, req.user.sub, ProjectRole.VIEWER);
 
     const [projectTaskRows, projectSectionRows, outbox] = await Promise.all([
       this.prisma.task.findMany({ where: { projectId }, select: { id: true } }),

--- a/apps/core-api/src/auth/auth.guard.ts
+++ b/apps/core-api/src/auth/auth.guard.ts
@@ -1,20 +1,22 @@
-import { CanActivate, ExecutionContext, ForbiddenException, Inject, Injectable } from '@nestjs/common';
+import { CanActivate, ExecutionContext, Inject, Injectable } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import type { AppRequest } from '../common/types';
 import { PrismaService } from '../prisma/prisma.service';
-import { GuestAccessScopeType, GuestAccessStatus, Prisma, UserStatus } from '@prisma/client';
+import { GuestAccessScopeType, GuestAccessStatus, Prisma } from '@prisma/client';
+import { IdentityService } from '../common/identity.service';
 
 @Injectable()
 export class AuthGuard implements CanActivate {
   constructor(
     @Inject(AuthService) private readonly authService: AuthService,
     @Inject(PrismaService) private readonly prisma: PrismaService,
+    @Inject(IdentityService) private readonly identity: IdentityService,
   ) {}
 
   canActivate = async (context: ExecutionContext): Promise<boolean> => {
     const req = context.switchToHttp().getRequest<AppRequest>();
     req.user = await this.authService.verify(req.headers.authorization, req.headers.cookie);
-    await this.syncAuthenticatedUser(req.user.sub, req.user.email, req.user.name);
+    await this.identity.syncAuthenticatedUser(req.user);
     const normalizedEmail = (req.user.email ?? '').trim().toLowerCase();
     if (normalizedEmail) {
       await this.acceptPendingInvitations(req.user.sub, normalizedEmail, req.correlationId ?? 'n/a');
@@ -22,52 +24,6 @@ export class AuthGuard implements CanActivate {
     }
     return true;
   };
-
-  private async syncAuthenticatedUser(
-    userId: string,
-    email: string | undefined,
-    displayName?: string,
-  ) {
-    const now = new Date();
-    for (let attempt = 0; attempt < 3; attempt += 1) {
-      const existing = await this.prisma.user.findUnique({ where: { id: userId } });
-      if (existing?.status === UserStatus.SUSPENDED) {
-        throw new ForbiddenException('User is suspended');
-      }
-      const normalizedEmail = (email ?? existing?.email ?? '').trim().toLowerCase();
-
-      try {
-        if (!existing) {
-          await this.prisma.user.create({
-            data: {
-              id: userId,
-              email: normalizedEmail || null,
-              displayName,
-              status: UserStatus.ACTIVE,
-              lastSeenAt: now,
-            },
-          });
-          return;
-        }
-
-        await this.prisma.user.update({
-          where: { id: userId },
-          data: {
-            email: normalizedEmail || null,
-            lastSeenAt: now,
-          },
-        });
-        return;
-      } catch (error) {
-        const maybePrismaError = error as { code?: string };
-        const isRetryableRace =
-          maybePrismaError.code === 'P2002' || maybePrismaError.code === 'P2025';
-        if (!isRetryableRace || attempt === 2) {
-          throw error;
-        }
-      }
-    }
-  }
 
   private async acceptPendingInvitations(userId: string, email: string, correlationId: string) {
     const pending = await this.prisma.invitation.findMany({

--- a/apps/core-api/src/auth/auth.module.ts
+++ b/apps/core-api/src/auth/auth.module.ts
@@ -1,12 +1,13 @@
 import { Module } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { AuthGuard } from './auth.guard';
-import { PrismaService } from '../prisma/prisma.service';
 import { AuthController } from './auth.controller';
+import { CommonServicesModule } from '../common/common-services.module';
 
 @Module({
+  imports: [CommonServicesModule],
   controllers: [AuthController],
-  providers: [AuthService, AuthGuard, PrismaService],
-  exports: [AuthService, AuthGuard, PrismaService],
+  providers: [AuthService, AuthGuard],
+  exports: [AuthService, AuthGuard],
 })
 export class AuthModule {}

--- a/apps/core-api/src/auth/role.guard.ts
+++ b/apps/core-api/src/auth/role.guard.ts
@@ -8,7 +8,7 @@ import {
 } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { ProjectRole, WorkspaceRole } from '@prisma/client';
-import { DomainService } from '../common/domain.service';
+import { AuthorizationService } from '../common/authorization.service';
 import type { AppRequest } from '../common/types';
 
 type Source = 'params' | 'body' | 'query';
@@ -54,7 +54,7 @@ function resolveTargetId(req: AppRequest, selector: IdSelector): string | undefi
 export class ProjectRoleGuard implements CanActivate {
   constructor(
     @Inject(Reflector) private readonly reflector: Reflector,
-    @Inject(DomainService) private readonly domain: DomainService,
+    @Inject(AuthorizationService) private readonly authorization: AuthorizationService,
   ) {}
 
   async canActivate(context: ExecutionContext) {
@@ -69,7 +69,7 @@ export class ProjectRoleGuard implements CanActivate {
     if (!projectId) {
       throw new BadRequestException(`Missing project id: ${requirement.projectId.source}.${requirement.projectId.key}`);
     }
-    const membership = await this.domain.requireProjectRole(projectId, req.user.sub, requirement.minRole);
+    const membership = await this.authorization.requireProjectRole(projectId, req.user.sub, requirement.minRole);
     req.projectRole = membership.role;
     return true;
   }
@@ -79,7 +79,7 @@ export class ProjectRoleGuard implements CanActivate {
 export class WorkspaceRoleGuard implements CanActivate {
   constructor(
     @Inject(Reflector) private readonly reflector: Reflector,
-    @Inject(DomainService) private readonly domain: DomainService,
+    @Inject(AuthorizationService) private readonly authorization: AuthorizationService,
   ) {}
 
   async canActivate(context: ExecutionContext) {
@@ -96,7 +96,7 @@ export class WorkspaceRoleGuard implements CanActivate {
         `Missing workspace id: ${requirement.workspaceId.source}.${requirement.workspaceId.key}`,
       );
     }
-    const membership = await this.domain.requireWorkspaceRole(workspaceId, req.user.sub, requirement.minRole);
+    const membership = await this.authorization.requireWorkspaceRole(workspaceId, req.user.sub, requirement.minRole);
     req.workspaceRole = membership.role;
     return true;
   }

--- a/apps/core-api/src/capacity/capacity.module.ts
+++ b/apps/core-api/src/capacity/capacity.module.ts
@@ -1,14 +1,13 @@
 import { Module } from '@nestjs/common';
 import { AuthModule } from '../auth/auth.module';
-import { DomainService } from '../common/domain.service';
-import { PrismaService } from '../prisma/prisma.service';
+import { CommonServicesModule } from '../common/common-services.module';
 import { CapacityController } from './capacity.controller';
 import { CapacityService } from './capacity.service';
 
 @Module({
-  imports: [AuthModule],
+  imports: [AuthModule, CommonServicesModule],
   controllers: [CapacityController],
-  providers: [CapacityService, PrismaService, DomainService],
+  providers: [CapacityService],
   exports: [CapacityService],
 })
 export class CapacityModule {}

--- a/apps/core-api/src/capacity/capacity.service.ts
+++ b/apps/core-api/src/capacity/capacity.service.ts
@@ -12,14 +12,16 @@ import {
   TimeOffEvent,
   WorkspaceRole,
 } from '@prisma/client';
-import { DomainService } from '../common/domain.service';
+import { AuditOutboxService } from '../common/audit-outbox.service';
+import { AuthorizationService } from '../common/authorization.service';
 import { PrismaService } from '../prisma/prisma.service';
 
 @Injectable()
 export class CapacityService {
   constructor(
     @Inject(PrismaService) private readonly prisma: PrismaService,
-    @Inject(DomainService) private readonly domain: DomainService,
+    @Inject(AuditOutboxService) private readonly auditOutbox: AuditOutboxService,
+    @Inject(AuthorizationService) private readonly authorization: AuthorizationService,
   ) {}
 
   private readonly DEFAULT_WEEKLY_CAPACITY_MINUTES = 40 * 60;
@@ -37,7 +39,7 @@ export class CapacityService {
       daysOfWeek: number[];
     },
   ) {
-    await this.domain.requireWorkspaceRole(workspaceId, actorUserId, WorkspaceRole.WS_ADMIN);
+    await this.authorization.requireWorkspaceRole(workspaceId, actorUserId, WorkspaceRole.WS_ADMIN);
     const normalized = await this.normalizeScheduleInput(workspaceId, input);
 
     try {
@@ -49,7 +51,7 @@ export class CapacityService {
           },
         });
 
-        await this.domain.appendAuditOutbox({
+        await this.auditOutbox.appendAuditOutbox({
           tx,
           actor: actorUserId,
           entityType: 'CapacitySchedule',
@@ -70,7 +72,7 @@ export class CapacityService {
   }
 
   async listCapacitySchedules(workspaceId: string, actorUserId: string) {
-    await this.domain.requireWorkspaceMembership(workspaceId, actorUserId);
+    await this.authorization.requireWorkspaceMembership(workspaceId, actorUserId);
 
     const schedules = await this.prisma.capacitySchedule.findMany({
       where: { workspaceId },
@@ -98,7 +100,7 @@ export class CapacityService {
       throw new NotFoundException('Capacity schedule not found');
     }
 
-    await this.domain.requireWorkspaceRole(existing.workspaceId, actorUserId, WorkspaceRole.WS_ADMIN);
+    await this.authorization.requireWorkspaceRole(existing.workspaceId, actorUserId, WorkspaceRole.WS_ADMIN);
     const normalized = this.normalizeSchedulePatch(input);
 
     return this.prisma.$transaction(async (tx) => {
@@ -107,7 +109,7 @@ export class CapacityService {
         data: normalized,
       });
 
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor: actorUserId,
         entityType: 'CapacitySchedule',
@@ -136,7 +138,7 @@ export class CapacityService {
       reason?: string;
     },
   ) {
-    await this.domain.requireWorkspaceRole(workspaceId, actorUserId, WorkspaceRole.WS_ADMIN);
+    await this.authorization.requireWorkspaceRole(workspaceId, actorUserId, WorkspaceRole.WS_ADMIN);
     await this.requireWorkspaceUser(workspaceId, input.userId);
     const normalized = this.normalizeTimeOffInput(input);
 
@@ -149,7 +151,7 @@ export class CapacityService {
         },
       });
 
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor: actorUserId,
         entityType: 'TimeOffEvent',
@@ -166,7 +168,7 @@ export class CapacityService {
   }
 
   async listTimeOff(workspaceId: string, actorUserId: string, userId?: string) {
-    await this.domain.requireWorkspaceMembership(workspaceId, actorUserId);
+    await this.authorization.requireWorkspaceMembership(workspaceId, actorUserId);
     if (userId) {
       await this.requireWorkspaceUser(workspaceId, userId);
     }
@@ -200,7 +202,7 @@ export class CapacityService {
       throw new NotFoundException('Time off event not found');
     }
 
-    await this.domain.requireWorkspaceRole(existing.workspaceId, actorUserId, WorkspaceRole.WS_ADMIN);
+    await this.authorization.requireWorkspaceRole(existing.workspaceId, actorUserId, WorkspaceRole.WS_ADMIN);
     const normalized = this.normalizeTimeOffPatch(existing, input);
 
     return this.prisma.$transaction(async (tx) => {
@@ -209,7 +211,7 @@ export class CapacityService {
         data: normalized,
       });
 
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor: actorUserId,
         entityType: 'TimeOffEvent',
@@ -234,14 +236,14 @@ export class CapacityService {
       throw new NotFoundException('Time off event not found');
     }
 
-    await this.domain.requireWorkspaceRole(existing.workspaceId, actorUserId, WorkspaceRole.WS_ADMIN);
+    await this.authorization.requireWorkspaceRole(existing.workspaceId, actorUserId, WorkspaceRole.WS_ADMIN);
 
     await this.prisma.$transaction(async (tx) => {
       await tx.timeOffEvent.delete({
         where: { id: timeOffId },
       });
 
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor: actorUserId,
         entityType: 'TimeOffEvent',
@@ -454,7 +456,7 @@ export class CapacityService {
   }
 
   private async requireWorkspaceUser(workspaceId: string, userId: string) {
-    await this.domain.requireWorkspaceMembership(workspaceId, userId);
+    await this.authorization.requireWorkspaceMembership(workspaceId, userId);
   }
 
   private normalizeRequiredString(value: string, field: string) {

--- a/apps/core-api/src/collab/collab.controller.ts
+++ b/apps/core-api/src/collab/collab.controller.ts
@@ -16,7 +16,8 @@ import { IsIn, IsObject, IsOptional, IsString } from 'class-validator';
 import { SignJWT } from 'jose';
 import { createSecretKey, randomUUID } from 'node:crypto';
 import { PrismaService } from '../prisma/prisma.service';
-import { DomainService } from '../common/domain.service';
+import { AuditOutboxService } from '../common/audit-outbox.service';
+import { AuthorizationService } from '../common/authorization.service';
 import { AuthGuard } from '../auth/auth.guard';
 import { CurrentRequest } from '../common/current-request';
 import type { AppRequest } from '../common/types';
@@ -53,7 +54,8 @@ export class CollabController {
 
   constructor(
     @Inject(PrismaService) private readonly prisma: PrismaService,
-    @Inject(DomainService) private readonly domain: DomainService,
+    @Inject(AuditOutboxService) private readonly auditOutbox: AuditOutboxService,
+    @Inject(AuthorizationService) private readonly authorization: AuthorizationService,
     @Inject(NotificationsService) private readonly notifications: NotificationsService,
   ) {}
 
@@ -61,7 +63,7 @@ export class CollabController {
   @UseGuards(AuthGuard)
   async issueToken(@Param('id') taskId: string, @CurrentRequest() req: AppRequest) {
     const task = await this.prisma.task.findUniqueOrThrow({ where: { id: taskId } });
-    const membership = await this.domain.requireProjectRole(task.projectId, req.user.sub, ProjectRole.VIEWER);
+    const membership = await this.authorization.requireProjectRole(task.projectId, req.user.sub, ProjectRole.VIEWER);
 
     const mode: 'readonly' | 'readwrite' = membership.role === ProjectRole.VIEWER ? 'readonly' : 'readwrite';
     const roomId = `task:${taskId}:description`;
@@ -192,7 +194,7 @@ export class CollabController {
           snapshotActor,
         );
 
-        await this.domain.appendAuditOutbox({
+        await this.auditOutbox.appendAuditOutbox({
           tx,
           actor: snapshotActor,
           entityType: 'Task',
@@ -396,7 +398,7 @@ export class CollabController {
       const created = await tx.taskMention.create({
         data: { taskId, mentionedUserId: userId, sourceType: 'description', sourceId: '' },
       });
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor,
         entityType: 'Task',
@@ -420,7 +422,7 @@ export class CollabController {
 
     for (const mention of toDelete) {
       await tx.taskMention.delete({ where: { id: mention.id } });
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor,
         entityType: 'Task',

--- a/apps/core-api/src/common/audit-outbox.service.ts
+++ b/apps/core-api/src/common/audit-outbox.service.ts
@@ -3,6 +3,16 @@ import { Prisma } from '@prisma/client';
 
 @Injectable()
 export class AuditOutboxService {
+  private normalizeJson(value: unknown): Prisma.InputJsonValue | typeof Prisma.JsonNull | undefined {
+    if (value === undefined) {
+      return undefined;
+    }
+    if (value === null) {
+      return Prisma.JsonNull;
+    }
+    return JSON.parse(JSON.stringify(value)) as Prisma.InputJsonValue;
+  }
+
   async appendAuditOutbox(args: {
     tx: Prisma.TransactionClient;
     actor: string;
@@ -16,19 +26,9 @@ export class AuditOutboxService {
     payload: unknown;
   }) {
     const correlationId = args.correlationId ?? 'test-correlation-id';
-    const beforeJson =
-      args.beforeJson === undefined
-        ? undefined
-        : args.beforeJson === null
-          ? Prisma.JsonNull
-          : (args.beforeJson as Prisma.InputJsonValue);
-    const afterJson =
-      args.afterJson === undefined
-        ? undefined
-        : args.afterJson === null
-          ? Prisma.JsonNull
-          : (args.afterJson as Prisma.InputJsonValue);
-    const payload = args.payload === null ? Prisma.JsonNull : (args.payload as Prisma.InputJsonValue);
+    const beforeJson = this.normalizeJson(args.beforeJson);
+    const afterJson = this.normalizeJson(args.afterJson);
+    const payload = this.normalizeJson(args.payload) ?? Prisma.JsonNull;
 
     await args.tx.auditEvent.create({
       data: {

--- a/apps/core-api/src/common/audit-outbox.service.ts
+++ b/apps/core-api/src/common/audit-outbox.service.ts
@@ -1,0 +1,52 @@
+import { Injectable } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+
+@Injectable()
+export class AuditOutboxService {
+  async appendAuditOutbox(args: {
+    tx: Prisma.TransactionClient;
+    actor: string;
+    entityType: string;
+    entityId: string;
+    action: string;
+    beforeJson?: unknown;
+    afterJson?: unknown;
+    correlationId?: string;
+    outboxType: string;
+    payload: unknown;
+  }) {
+    const correlationId = args.correlationId ?? 'test-correlation-id';
+    const beforeJson =
+      args.beforeJson === undefined
+        ? undefined
+        : args.beforeJson === null
+          ? Prisma.JsonNull
+          : (args.beforeJson as Prisma.InputJsonValue);
+    const afterJson =
+      args.afterJson === undefined
+        ? undefined
+        : args.afterJson === null
+          ? Prisma.JsonNull
+          : (args.afterJson as Prisma.InputJsonValue);
+    const payload = args.payload === null ? Prisma.JsonNull : (args.payload as Prisma.InputJsonValue);
+
+    await args.tx.auditEvent.create({
+      data: {
+        actor: args.actor,
+        entityType: args.entityType,
+        entityId: args.entityId,
+        action: args.action,
+        beforeJson,
+        afterJson,
+        correlationId,
+      },
+    });
+    await args.tx.outboxEvent.create({
+      data: {
+        type: args.outboxType,
+        payload,
+        correlationId,
+      },
+    });
+  }
+}

--- a/apps/core-api/src/common/authorization.service.ts
+++ b/apps/core-api/src/common/authorization.service.ts
@@ -1,0 +1,76 @@
+import { ForbiddenException, Inject, Injectable, NotFoundException } from '@nestjs/common';
+import { GuestAccessScopeType, GuestAccessStatus, ProjectRole, WorkspaceRole } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
+
+@Injectable()
+export class AuthorizationService {
+  private static readonly workspaceRoleRank: Record<WorkspaceRole, number> = { WS_MEMBER: 1, WS_ADMIN: 2 };
+  private static readonly projectRoleRank: Record<ProjectRole, number> = { VIEWER: 1, MEMBER: 2, ADMIN: 3 };
+
+  constructor(@Inject(PrismaService) private readonly prisma: PrismaService) {}
+
+  async requireWorkspaceRole(workspaceId: string, userId: string, min: WorkspaceRole) {
+    const membership = await this.prisma.workspaceMembership.findUnique({
+      where: { workspaceId_userId: { workspaceId, userId } },
+    });
+    if (!membership) throw new NotFoundException('Workspace membership not found');
+    if (AuthorizationService.workspaceRoleRank[membership.role] < AuthorizationService.workspaceRoleRank[min]) {
+      throw new ForbiddenException('Insufficient workspace role');
+    }
+    return membership;
+  }
+
+  async requireWorkspaceMembership(workspaceId: string, userId: string) {
+    const membership = await this.prisma.workspaceMembership.findUnique({
+      where: { workspaceId_userId: { workspaceId, userId } },
+    });
+    if (!membership) throw new NotFoundException('Workspace membership not found');
+    return membership;
+  }
+
+  async requireProjectRole(projectId: string, userId: string, min: ProjectRole) {
+    const membership = await this.prisma.projectMembership.findUnique({
+      where: { projectId_userId: { projectId, userId } },
+    });
+    if (membership) {
+      if (AuthorizationService.projectRoleRank[membership.role] < AuthorizationService.projectRoleRank[min]) {
+        throw new ForbiddenException('Insufficient role');
+      }
+      return membership;
+    }
+
+    const guestGrant = await this.prisma.guestAccessGrant.findFirst({
+      where: {
+        userId,
+        projectId,
+        scopeType: GuestAccessScopeType.PROJECT,
+      },
+      orderBy: { updatedAt: 'desc' },
+    });
+    if (!guestGrant) {
+      throw new NotFoundException('Project membership not found');
+    }
+    if (guestGrant.status === GuestAccessStatus.REVOKED || guestGrant.revokedAt) {
+      throw new ForbiddenException('Guest access has been revoked');
+    }
+    if (
+      guestGrant.status === GuestAccessStatus.EXPIRED ||
+      (guestGrant.expiresAt && guestGrant.expiresAt.getTime() <= Date.now())
+    ) {
+      throw new ForbiddenException('Guest access has expired');
+    }
+    if (!guestGrant.projectRole) {
+      throw new ForbiddenException('Guest project access is not configured');
+    }
+    if (AuthorizationService.projectRoleRank[guestGrant.projectRole] < AuthorizationService.projectRoleRank[min]) {
+      throw new ForbiddenException('Insufficient role');
+    }
+    return {
+      id: guestGrant.id,
+      projectId,
+      userId,
+      role: guestGrant.projectRole,
+      createdAt: guestGrant.createdAt,
+    };
+  }
+}

--- a/apps/core-api/src/common/common-services.module.ts
+++ b/apps/core-api/src/common/common-services.module.ts
@@ -1,0 +1,28 @@
+import { Global, Module } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { AuditOutboxService } from './audit-outbox.service';
+import { AuthorizationService } from './authorization.service';
+import { DomainService } from './domain.service';
+import { IdentityService } from './identity.service';
+import { WorkspaceDefaultsService } from './workspace-defaults.service';
+
+@Global()
+@Module({
+  providers: [
+    PrismaService,
+    AuditOutboxService,
+    AuthorizationService,
+    DomainService,
+    IdentityService,
+    WorkspaceDefaultsService,
+  ],
+  exports: [
+    PrismaService,
+    AuditOutboxService,
+    AuthorizationService,
+    DomainService,
+    IdentityService,
+    WorkspaceDefaultsService,
+  ],
+})
+export class CommonServicesModule {}

--- a/apps/core-api/src/common/domain.service.ts
+++ b/apps/core-api/src/common/domain.service.ts
@@ -1,11 +1,5 @@
-import { Injectable, BadRequestException, ConflictException, Inject } from '@nestjs/common';
-import {
-  Prisma,
-  ProjectRole,
-  TaskStatus,
-  TaskType,
-  WorkspaceRole,
-} from '@prisma/client';
+import { Injectable, BadRequestException, ConflictException } from '@nestjs/common';
+import { TaskStatus, TaskType } from '@prisma/client';
 import {
   applyTaskProgressAutomation,
   assertTimelineScheduleRange as assertTimelineScheduleRangeInDomain,
@@ -17,77 +11,13 @@ import {
   type TaskStatus as DomainTaskStatus,
   type TaskType as DomainTaskType,
 } from '@atlaspm/domain';
-import type { AuthUser } from './types';
-import { AuditOutboxService } from './audit-outbox.service';
-import { AuthorizationService } from './authorization.service';
-import { IdentityService } from './identity.service';
-import { WorkspaceDefaultsService } from './workspace-defaults.service';
 
 @Injectable()
 export class DomainService {
   private static readonly defaultRuleTemplateKeys = ['progress_to_done', 'progress_to_in_progress'] as const;
 
-  constructor(
-    @Inject(AuditOutboxService) private readonly auditOutbox: AuditOutboxService,
-    @Inject(AuthorizationService) private readonly authorization: AuthorizationService,
-    @Inject(IdentityService) private readonly identity: IdentityService,
-    @Inject(WorkspaceDefaultsService) private readonly defaults: WorkspaceDefaultsService,
-  ) {}
-
   isDefaultRuleTemplateKey(templateKey: string): boolean {
     return DomainService.defaultRuleTemplateKeys.includes(templateKey as typeof DomainService.defaultRuleTemplateKeys[number]);
-  }
-
-  async ensureUser(sub: string, email?: string, name?: string) {
-    return this.identity.ensureUser(sub, email, name);
-  }
-
-  async syncAuthenticatedUser(user: AuthUser) {
-    return this.identity.syncAuthenticatedUser(user);
-  }
-
-  async ensureDefaultWorkspaceForUser(sub: string) {
-    return this.defaults.ensureDefaultWorkspaceForUser(sub);
-  }
-
-  async requireWorkspaceRole(workspaceId: string, userId: string, min: WorkspaceRole) {
-    return this.authorization.requireWorkspaceRole(workspaceId, userId, min);
-  }
-
-  async requireWorkspaceMembership(workspaceId: string, userId: string) {
-    return this.authorization.requireWorkspaceMembership(workspaceId, userId);
-  }
-
-  async requireProjectRole(projectId: string, userId: string, min: ProjectRole) {
-    return this.authorization.requireProjectRole(projectId, userId, min);
-  }
-
-  async appendAuditOutbox(args: {
-    tx: Prisma.TransactionClient;
-    actor: string;
-    entityType: string;
-    entityId: string;
-    action: string;
-    beforeJson?: unknown;
-    afterJson?: unknown;
-    correlationId?: string;
-    outboxType: string;
-    payload: unknown;
-  }) {
-    return this.auditOutbox.appendAuditOutbox(args);
-  }
-
-  async ensureProjectDefaults(projectId: string, actor: string, correlationId: string) {
-    return this.defaults.ensureProjectDefaults(projectId, actor, correlationId);
-  }
-
-  async ensureProjectDefaultsInTx(
-    tx: Prisma.TransactionClient,
-    projectId: string,
-    actor: string,
-    correlationId: string,
-  ) {
-    return this.defaults.ensureProjectDefaultsInTx(tx, projectId, actor, correlationId);
   }
 
   ensureProgressRange(progressPercent?: number) {

--- a/apps/core-api/src/common/domain.service.ts
+++ b/apps/core-api/src/common/domain.service.ts
@@ -1,13 +1,9 @@
-import { Injectable, ForbiddenException, NotFoundException, ConflictException, Inject, BadRequestException } from '@nestjs/common';
-import { PrismaService } from '../prisma/prisma.service';
+import { Injectable, BadRequestException, ConflictException, Inject } from '@nestjs/common';
 import {
-  GuestAccessStatus,
-  GuestAccessScopeType,
   Prisma,
   ProjectRole,
   TaskStatus,
   TaskType,
-  UserStatus,
   WorkspaceRole,
 } from '@prisma/client';
 import {
@@ -21,186 +17,49 @@ import {
   type TaskStatus as DomainTaskStatus,
   type TaskType as DomainTaskType,
 } from '@atlaspm/domain';
-import { templateDefinition } from '../rules/rule-definition';
 import type { AuthUser } from './types';
+import { AuditOutboxService } from './audit-outbox.service';
+import { AuthorizationService } from './authorization.service';
+import { IdentityService } from './identity.service';
+import { WorkspaceDefaultsService } from './workspace-defaults.service';
 
 @Injectable()
 export class DomainService {
   private static readonly defaultRuleTemplateKeys = ['progress_to_done', 'progress_to_in_progress'] as const;
-  private static readonly defaultWorkspaceRetryDelaysMs = [10, 25, 50, 100, 200, 400];
-  private static readonly workspaceRoleRank: Record<WorkspaceRole, number> = { WS_MEMBER: 1, WS_ADMIN: 2 };
-  private static readonly projectRoleRank: Record<ProjectRole, number> = { VIEWER: 1, MEMBER: 2, ADMIN: 3 };
 
-  constructor(@Inject(PrismaService) private readonly prisma: PrismaService) {}
+  constructor(
+    @Inject(AuditOutboxService) private readonly auditOutbox: AuditOutboxService,
+    @Inject(AuthorizationService) private readonly authorization: AuthorizationService,
+    @Inject(IdentityService) private readonly identity: IdentityService,
+    @Inject(WorkspaceDefaultsService) private readonly defaults: WorkspaceDefaultsService,
+  ) {}
 
   isDefaultRuleTemplateKey(templateKey: string): boolean {
     return DomainService.defaultRuleTemplateKeys.includes(templateKey as typeof DomainService.defaultRuleTemplateKeys[number]);
   }
 
   async ensureUser(sub: string, email?: string, name?: string) {
-    const existing = await this.prisma.user.findUnique({ where: { id: sub } });
-    if (!existing) {
-      return this.prisma.user.create({
-        data: { id: sub, email, displayName: name, status: UserStatus.ACTIVE },
-      });
-    }
-    return this.prisma.user.update({
-      where: { id: sub },
-      data: {
-        email,
-        displayName: existing.displayName ?? name,
-      },
-    });
+    return this.identity.ensureUser(sub, email, name);
   }
 
   async syncAuthenticatedUser(user: AuthUser) {
-    const existing = await this.prisma.user.findUnique({ where: { id: user.sub } });
-    const now = new Date();
-    if (!existing) {
-      return this.prisma.user.create({
-        data: {
-          id: user.sub,
-          email: user.email,
-          displayName: user.name,
-          status: UserStatus.ACTIVE,
-          lastSeenAt: now,
-        },
-      });
-    }
-    if (existing.status === UserStatus.SUSPENDED) {
-      throw new ForbiddenException('User is suspended');
-    }
-    return this.prisma.user.update({
-      where: { id: user.sub },
-      data: {
-        email: user.email,
-        displayName: existing.displayName ?? user.name,
-        lastSeenAt: now,
-      },
-    });
+    return this.identity.syncAuthenticatedUser(user);
   }
 
   async ensureDefaultWorkspaceForUser(sub: string) {
-    for (let attempt = 0; attempt < DomainService.defaultWorkspaceRetryDelaysMs.length; attempt += 1) {
-      try {
-        return await this.prisma.$transaction(async (tx) => {
-          let membership = await tx.workspaceMembership.findFirst({
-            where: { userId: sub },
-            include: { workspace: true },
-          });
-
-          if (!membership) {
-            const ws = await tx.workspace.create({ data: { name: 'Default Workspace' } });
-            membership = await tx.workspaceMembership.create({
-              data: { workspaceId: ws.id, userId: sub, role: WorkspaceRole.WS_ADMIN },
-              include: { workspace: true },
-            });
-          }
-
-          return membership.workspace;
-        }, {
-          maxWait: 5000,
-          timeout: 10000,
-          isolationLevel: 'Serializable',
-        });
-      } catch (error) {
-        const maybePrismaError = error as { code?: string; message?: string };
-        const isRetryableTxnConflict =
-          maybePrismaError.code === 'P2034' ||
-          maybePrismaError.message?.includes('write conflict') ||
-          maybePrismaError.message?.includes('deadlock') ||
-          maybePrismaError.message?.includes('serialization');
-
-        if (!isRetryableTxnConflict || attempt === DomainService.defaultWorkspaceRetryDelaysMs.length - 1) {
-          const membership = await this.prisma.workspaceMembership.findFirst({
-            where: { userId: sub },
-            include: { workspace: true },
-          });
-          if (membership) {
-            return membership.workspace;
-          }
-          throw error;
-        }
-
-        const membership = await this.prisma.workspaceMembership.findFirst({
-          where: { userId: sub },
-          include: { workspace: true },
-        });
-        if (membership) {
-          return membership.workspace;
-        }
-
-        const delayMs = DomainService.defaultWorkspaceRetryDelaysMs[attempt];
-        await new Promise((resolve) => setTimeout(resolve, delayMs));
-      }
-    }
-
-    throw new ConflictException('Failed to ensure default workspace');
+    return this.defaults.ensureDefaultWorkspaceForUser(sub);
   }
 
   async requireWorkspaceRole(workspaceId: string, userId: string, min: WorkspaceRole) {
-    const membership = await this.prisma.workspaceMembership.findUnique({
-      where: { workspaceId_userId: { workspaceId, userId } },
-    });
-    if (!membership) throw new NotFoundException('Workspace membership not found');
-    if (DomainService.workspaceRoleRank[membership.role] < DomainService.workspaceRoleRank[min]) {
-      throw new ForbiddenException('Insufficient workspace role');
-    }
-    return membership;
+    return this.authorization.requireWorkspaceRole(workspaceId, userId, min);
   }
 
   async requireWorkspaceMembership(workspaceId: string, userId: string) {
-    const membership = await this.prisma.workspaceMembership.findUnique({
-      where: { workspaceId_userId: { workspaceId, userId } },
-    });
-    if (!membership) throw new NotFoundException('Workspace membership not found');
-    return membership;
+    return this.authorization.requireWorkspaceMembership(workspaceId, userId);
   }
 
   async requireProjectRole(projectId: string, userId: string, min: ProjectRole) {
-    const membership = await this.prisma.projectMembership.findUnique({
-      where: { projectId_userId: { projectId, userId } },
-    });
-    if (membership) {
-      if (DomainService.projectRoleRank[membership.role] < DomainService.projectRoleRank[min]) {
-        throw new ForbiddenException('Insufficient role');
-      }
-      return membership;
-    }
-
-    const guestGrant = await this.prisma.guestAccessGrant.findFirst({
-      where: {
-        userId,
-        projectId,
-        scopeType: GuestAccessScopeType.PROJECT,
-      },
-      orderBy: { updatedAt: 'desc' },
-    });
-    if (!guestGrant) {
-      throw new NotFoundException('Project membership not found');
-    }
-    if (guestGrant.status === GuestAccessStatus.REVOKED || guestGrant.revokedAt) {
-      throw new ForbiddenException('Guest access has been revoked');
-    }
-    if (
-      guestGrant.status === GuestAccessStatus.EXPIRED ||
-      (guestGrant.expiresAt && guestGrant.expiresAt.getTime() <= Date.now())
-    ) {
-      throw new ForbiddenException('Guest access has expired');
-    }
-    if (!guestGrant.projectRole) {
-      throw new ForbiddenException('Guest project access is not configured');
-    }
-    if (DomainService.projectRoleRank[guestGrant.projectRole] < DomainService.projectRoleRank[min]) {
-      throw new ForbiddenException('Insufficient role');
-    }
-    return {
-      id: guestGrant.id,
-      projectId,
-      userId,
-      role: guestGrant.projectRole,
-      createdAt: guestGrant.createdAt,
-    };
+    return this.authorization.requireProjectRole(projectId, userId, min);
   }
 
   async appendAuditOutbox(args: {
@@ -215,93 +74,11 @@ export class DomainService {
     outboxType: string;
     payload: unknown;
   }) {
-    const correlationId = args.correlationId ?? 'test-correlation-id';
-    const beforeJson =
-      args.beforeJson === undefined
-        ? undefined
-        : args.beforeJson === null
-          ? Prisma.JsonNull
-          : (args.beforeJson as Prisma.InputJsonValue);
-    const afterJson =
-      args.afterJson === undefined
-        ? undefined
-        : args.afterJson === null
-          ? Prisma.JsonNull
-          : (args.afterJson as Prisma.InputJsonValue);
-    const payload =
-      args.payload === null ? Prisma.JsonNull : (args.payload as Prisma.InputJsonValue);
-
-    await args.tx.auditEvent.create({
-      data: {
-        actor: args.actor,
-        entityType: args.entityType,
-        entityId: args.entityId,
-        action: args.action,
-        beforeJson,
-        afterJson,
-        correlationId,
-      },
-    });
-    await args.tx.outboxEvent.create({
-      data: {
-        type: args.outboxType,
-        payload,
-        correlationId,
-      },
-    });
+    return this.auditOutbox.appendAuditOutbox(args);
   }
 
   async ensureProjectDefaults(projectId: string, actor: string, correlationId: string) {
-    const tx = this.prisma;
-    const defaultSection = await tx.section.findFirst({ where: { projectId, isDefault: true } });
-    if (!defaultSection) {
-      const section = await tx.section.create({
-        data: { projectId, name: 'No Section', isDefault: true, position: 1000 },
-      });
-      await this.appendAuditOutbox({
-        tx,
-        actor,
-        entityType: 'Section',
-        entityId: section.id,
-        action: 'section.created.default',
-        afterJson: section,
-        correlationId,
-        outboxType: 'section.created',
-        payload: section,
-      });
-    }
-
-    const templates = [
-      { name: 'Progress to Done', templateKey: 'progress_to_done' },
-      { name: 'Progress to In Progress', templateKey: 'progress_to_in_progress' },
-    ] as const;
-    for (const tpl of templates) {
-      const rule = await tx.rule.upsert({
-        where: { projectId_templateKey: { projectId, templateKey: tpl.templateKey } },
-        create: {
-          projectId,
-          name: tpl.name,
-          templateKey: tpl.templateKey,
-          definition: templateDefinition(tpl.templateKey) as Prisma.InputJsonValue,
-          enabled: true,
-          cooldownSec: 60,
-        },
-        update: {
-          definition: templateDefinition(tpl.templateKey) as Prisma.InputJsonValue,
-        },
-      });
-      await this.appendAuditOutbox({
-        tx,
-        actor,
-        entityType: 'Rule',
-        entityId: rule.id,
-        action: 'rule.ensure_template',
-        afterJson: rule,
-        correlationId,
-        outboxType: 'rule.created',
-        payload: rule,
-      });
-    }
+    return this.defaults.ensureProjectDefaults(projectId, actor, correlationId);
   }
 
   async ensureProjectDefaultsInTx(
@@ -310,63 +87,7 @@ export class DomainService {
     actor: string,
     correlationId: string,
   ) {
-    const defaultSection = await tx.section.findFirst({ where: { projectId, isDefault: true } });
-    if (!defaultSection) {
-      const section = await tx.section.create({
-        data: { projectId, name: 'No Section', isDefault: true, position: 1000 },
-      });
-      await this.appendAuditOutbox({
-        tx,
-        actor,
-        entityType: 'Section',
-        entityId: section.id,
-        action: 'section.created.default',
-        afterJson: section,
-        correlationId,
-        outboxType: 'section.created',
-        payload: section,
-      });
-    }
-
-    const templates = [
-      { name: 'Progress to Done', templateKey: 'progress_to_done' },
-      { name: 'Progress to In Progress', templateKey: 'progress_to_in_progress' },
-    ] as const;
-    for (const tpl of templates) {
-      const existing = await tx.rule.findUnique({
-        where: { projectId_templateKey: { projectId, templateKey: tpl.templateKey } },
-      });
-      if (existing) {
-        if (!existing.definition) {
-          await tx.rule.update({
-            where: { id: existing.id },
-            data: { definition: templateDefinition(tpl.templateKey) as Prisma.InputJsonValue },
-          });
-        }
-        continue;
-      }
-      const rule = await tx.rule.create({
-        data: {
-          projectId,
-          name: tpl.name,
-          templateKey: tpl.templateKey,
-          definition: templateDefinition(tpl.templateKey) as Prisma.InputJsonValue,
-          enabled: true,
-          cooldownSec: 60,
-        },
-      });
-      await this.appendAuditOutbox({
-        tx,
-        actor,
-        entityType: 'Rule',
-        entityId: rule.id,
-        action: 'rule.ensure_template',
-        afterJson: rule,
-        correlationId,
-        outboxType: 'rule.created',
-        payload: rule,
-      });
-    }
+    return this.defaults.ensureProjectDefaultsInTx(tx, projectId, actor, correlationId);
   }
 
   ensureProgressRange(progressPercent?: number) {

--- a/apps/core-api/src/common/identity.service.ts
+++ b/apps/core-api/src/common/identity.service.ts
@@ -16,11 +16,15 @@ export class IdentityService {
       });
     }
 
-    const data: { displayName?: string | null; email?: string | null } = {
-      displayName: existing.displayName ?? name,
-    };
+    const data: { displayName?: string | null; email?: string | null } = {};
+    if (existing.displayName == null && name !== undefined) {
+      data.displayName = name;
+    }
     if (normalizedEmail !== undefined) {
       data.email = normalizedEmail;
+    }
+    if (Object.keys(data).length === 0) {
+      return existing;
     }
 
     return this.prisma.user.update({

--- a/apps/core-api/src/common/identity.service.ts
+++ b/apps/core-api/src/common/identity.service.ts
@@ -8,19 +8,24 @@ export class IdentityService {
   constructor(@Inject(PrismaService) private readonly prisma: PrismaService) {}
 
   async ensureUser(sub: string, email?: string, name?: string) {
-    const normalizedEmail = (email ?? '').trim().toLowerCase() || null;
     const existing = await this.prisma.user.findUnique({ where: { id: sub } });
+    const normalizedEmail = email === undefined ? undefined : email.trim().toLowerCase() || null;
     if (!existing) {
       return this.prisma.user.create({
-        data: { id: sub, email: normalizedEmail, displayName: name, status: UserStatus.ACTIVE },
+        data: { id: sub, email: normalizedEmail ?? null, displayName: name, status: UserStatus.ACTIVE },
       });
     }
+
+    const data: { displayName?: string | null; email?: string | null } = {
+      displayName: existing.displayName ?? name,
+    };
+    if (normalizedEmail !== undefined) {
+      data.email = normalizedEmail;
+    }
+
     return this.prisma.user.update({
       where: { id: sub },
-      data: {
-        email: normalizedEmail,
-        displayName: existing.displayName ?? name,
-      },
+      data,
     });
   }
 

--- a/apps/core-api/src/common/identity.service.ts
+++ b/apps/core-api/src/common/identity.service.ts
@@ -1,0 +1,66 @@
+import { ForbiddenException, Inject, Injectable } from '@nestjs/common';
+import { UserStatus } from '@prisma/client';
+import type { AuthUser } from './types';
+import { PrismaService } from '../prisma/prisma.service';
+
+@Injectable()
+export class IdentityService {
+  constructor(@Inject(PrismaService) private readonly prisma: PrismaService) {}
+
+  async ensureUser(sub: string, email?: string, name?: string) {
+    const normalizedEmail = (email ?? '').trim().toLowerCase() || null;
+    const existing = await this.prisma.user.findUnique({ where: { id: sub } });
+    if (!existing) {
+      return this.prisma.user.create({
+        data: { id: sub, email: normalizedEmail, displayName: name, status: UserStatus.ACTIVE },
+      });
+    }
+    return this.prisma.user.update({
+      where: { id: sub },
+      data: {
+        email: normalizedEmail,
+        displayName: existing.displayName ?? name,
+      },
+    });
+  }
+
+  async syncAuthenticatedUser(user: AuthUser) {
+    const now = new Date();
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      const existing = await this.prisma.user.findUnique({ where: { id: user.sub } });
+      if (existing?.status === UserStatus.SUSPENDED) {
+        throw new ForbiddenException('User is suspended');
+      }
+      const normalizedEmail = (user.email ?? existing?.email ?? '').trim().toLowerCase() || null;
+
+      try {
+        if (!existing) {
+          return await this.prisma.user.create({
+            data: {
+              id: user.sub,
+              email: normalizedEmail,
+              displayName: user.name,
+              status: UserStatus.ACTIVE,
+              lastSeenAt: now,
+            },
+          });
+        }
+
+        return await this.prisma.user.update({
+          where: { id: user.sub },
+          data: {
+            email: normalizedEmail,
+            displayName: existing.displayName ?? user.name,
+            lastSeenAt: now,
+          },
+        });
+      } catch (error) {
+        const maybePrismaError = error as { code?: string };
+        const isRetryableRace = maybePrismaError.code === 'P2002' || maybePrismaError.code === 'P2025';
+        if (!isRetryableRace || attempt === 2) {
+          throw error;
+        }
+      }
+    }
+  }
+}

--- a/apps/core-api/src/common/workspace-defaults.service.ts
+++ b/apps/core-api/src/common/workspace-defaults.service.ts
@@ -1,0 +1,194 @@
+import { ConflictException, Inject, Injectable } from '@nestjs/common';
+import { Prisma, WorkspaceRole } from '@prisma/client';
+import { templateDefinition } from '../rules/rule-definition';
+import { PrismaService } from '../prisma/prisma.service';
+import { AuditOutboxService } from './audit-outbox.service';
+
+@Injectable()
+export class WorkspaceDefaultsService {
+  private static readonly defaultWorkspaceRetryDelaysMs = [10, 25, 50, 100, 200, 400];
+
+  constructor(
+    @Inject(PrismaService) private readonly prisma: PrismaService,
+    @Inject(AuditOutboxService) private readonly auditOutbox: AuditOutboxService,
+  ) {}
+
+  async ensureDefaultWorkspaceForUser(sub: string) {
+    for (let attempt = 0; attempt < WorkspaceDefaultsService.defaultWorkspaceRetryDelaysMs.length; attempt += 1) {
+      try {
+        return await this.prisma.$transaction(
+          async (tx) => {
+            let membership = await tx.workspaceMembership.findFirst({
+              where: { userId: sub },
+              include: { workspace: true },
+            });
+
+            if (!membership) {
+              const ws = await tx.workspace.create({ data: { name: 'Default Workspace' } });
+              membership = await tx.workspaceMembership.create({
+                data: { workspaceId: ws.id, userId: sub, role: WorkspaceRole.WS_ADMIN },
+                include: { workspace: true },
+              });
+            }
+
+            return membership.workspace;
+          },
+          {
+            maxWait: 5000,
+            timeout: 10000,
+            isolationLevel: 'Serializable',
+          },
+        );
+      } catch (error) {
+        const maybePrismaError = error as { code?: string; message?: string };
+        const isRetryableTxnConflict =
+          maybePrismaError.code === 'P2034' ||
+          maybePrismaError.message?.includes('write conflict') ||
+          maybePrismaError.message?.includes('deadlock') ||
+          maybePrismaError.message?.includes('serialization');
+
+        if (!isRetryableTxnConflict || attempt === WorkspaceDefaultsService.defaultWorkspaceRetryDelaysMs.length - 1) {
+          const membership = await this.prisma.workspaceMembership.findFirst({
+            where: { userId: sub },
+            include: { workspace: true },
+          });
+          if (membership) {
+            return membership.workspace;
+          }
+          throw error;
+        }
+
+        const membership = await this.prisma.workspaceMembership.findFirst({
+          where: { userId: sub },
+          include: { workspace: true },
+        });
+        if (membership) {
+          return membership.workspace;
+        }
+
+        const delayMs = WorkspaceDefaultsService.defaultWorkspaceRetryDelaysMs[attempt];
+        await new Promise((resolve) => setTimeout(resolve, delayMs));
+      }
+    }
+
+    throw new ConflictException('Failed to ensure default workspace');
+  }
+
+  async ensureProjectDefaults(projectId: string, actor: string, correlationId: string) {
+    const tx = this.prisma;
+    const defaultSection = await tx.section.findFirst({ where: { projectId, isDefault: true } });
+    if (!defaultSection) {
+      const section = await tx.section.create({
+        data: { projectId, name: 'No Section', isDefault: true, position: 1000 },
+      });
+      await this.auditOutbox.appendAuditOutbox({
+        tx,
+        actor,
+        entityType: 'Section',
+        entityId: section.id,
+        action: 'section.created.default',
+        afterJson: section,
+        correlationId,
+        outboxType: 'section.created',
+        payload: section,
+      });
+    }
+
+    const templates = [
+      { name: 'Progress to Done', templateKey: 'progress_to_done' },
+      { name: 'Progress to In Progress', templateKey: 'progress_to_in_progress' },
+    ] as const;
+    for (const tpl of templates) {
+      const rule = await tx.rule.upsert({
+        where: { projectId_templateKey: { projectId, templateKey: tpl.templateKey } },
+        create: {
+          projectId,
+          name: tpl.name,
+          templateKey: tpl.templateKey,
+          definition: templateDefinition(tpl.templateKey) as Prisma.InputJsonValue,
+          enabled: true,
+          cooldownSec: 60,
+        },
+        update: {
+          definition: templateDefinition(tpl.templateKey) as Prisma.InputJsonValue,
+        },
+      });
+      await this.auditOutbox.appendAuditOutbox({
+        tx,
+        actor,
+        entityType: 'Rule',
+        entityId: rule.id,
+        action: 'rule.ensure_template',
+        afterJson: rule,
+        correlationId,
+        outboxType: 'rule.created',
+        payload: rule,
+      });
+    }
+  }
+
+  async ensureProjectDefaultsInTx(
+    tx: Prisma.TransactionClient,
+    projectId: string,
+    actor: string,
+    correlationId: string,
+  ) {
+    const defaultSection = await tx.section.findFirst({ where: { projectId, isDefault: true } });
+    if (!defaultSection) {
+      const section = await tx.section.create({
+        data: { projectId, name: 'No Section', isDefault: true, position: 1000 },
+      });
+      await this.auditOutbox.appendAuditOutbox({
+        tx,
+        actor,
+        entityType: 'Section',
+        entityId: section.id,
+        action: 'section.created.default',
+        afterJson: section,
+        correlationId,
+        outboxType: 'section.created',
+        payload: section,
+      });
+    }
+
+    const templates = [
+      { name: 'Progress to Done', templateKey: 'progress_to_done' },
+      { name: 'Progress to In Progress', templateKey: 'progress_to_in_progress' },
+    ] as const;
+    for (const tpl of templates) {
+      const existing = await tx.rule.findUnique({
+        where: { projectId_templateKey: { projectId, templateKey: tpl.templateKey } },
+      });
+      if (existing) {
+        if (!existing.definition) {
+          await tx.rule.update({
+            where: { id: existing.id },
+            data: { definition: templateDefinition(tpl.templateKey) as Prisma.InputJsonValue },
+          });
+        }
+        continue;
+      }
+      const rule = await tx.rule.create({
+        data: {
+          projectId,
+          name: tpl.name,
+          templateKey: tpl.templateKey,
+          definition: templateDefinition(tpl.templateKey) as Prisma.InputJsonValue,
+          enabled: true,
+          cooldownSec: 60,
+        },
+      });
+      await this.auditOutbox.appendAuditOutbox({
+        tx,
+        actor,
+        entityType: 'Rule',
+        entityId: rule.id,
+        action: 'rule.ensure_template',
+        afterJson: rule,
+        correlationId,
+        outboxType: 'rule.created',
+        payload: rule,
+      });
+    }
+  }
+}

--- a/apps/core-api/src/common/workspace-defaults.service.ts
+++ b/apps/core-api/src/common/workspace-defaults.service.ts
@@ -1,3 +1,4 @@
+import { isDeepStrictEqual } from 'node:util';
 import { ConflictException, Inject, Injectable } from '@nestjs/common';
 import { Prisma, WorkspaceRole } from '@prisma/client';
 import { templateDefinition } from '../rules/rule-definition';
@@ -142,7 +143,7 @@ export class WorkspaceDefaultsService {
         where: { projectId_templateKey: { projectId, templateKey: tpl.templateKey } },
       });
       if (existing) {
-        if (JSON.stringify(existing.definition) !== JSON.stringify(definition)) {
+        if (!isDeepStrictEqual(existing.definition, definition)) {
           const rule = await tx.rule.update({
             where: { id: existing.id },
             data: { definition },

--- a/apps/core-api/src/common/workspace-defaults.service.ts
+++ b/apps/core-api/src/common/workspace-defaults.service.ts
@@ -6,15 +6,25 @@ import { AuditOutboxService } from './audit-outbox.service';
 
 @Injectable()
 export class WorkspaceDefaultsService {
-  private static readonly defaultWorkspaceRetryDelaysMs = [10, 25, 50, 100, 200, 400];
+  private static readonly serializableRetryDelaysMs = [10, 25, 50, 100, 200, 400];
 
   constructor(
     @Inject(PrismaService) private readonly prisma: PrismaService,
     @Inject(AuditOutboxService) private readonly auditOutbox: AuditOutboxService,
   ) {}
 
+  private static isRetryableTransactionConflict(error: unknown) {
+    const maybePrismaError = error as { code?: string; message?: string };
+    return (
+      maybePrismaError.code === 'P2034' ||
+      maybePrismaError.message?.includes('write conflict') ||
+      maybePrismaError.message?.includes('deadlock') ||
+      maybePrismaError.message?.includes('serialization')
+    );
+  }
+
   async ensureDefaultWorkspaceForUser(sub: string) {
-    for (let attempt = 0; attempt < WorkspaceDefaultsService.defaultWorkspaceRetryDelaysMs.length; attempt += 1) {
+    for (let attempt = 0; attempt < WorkspaceDefaultsService.serializableRetryDelaysMs.length; attempt += 1) {
       try {
         return await this.prisma.$transaction(
           async (tx) => {
@@ -40,14 +50,10 @@ export class WorkspaceDefaultsService {
           },
         );
       } catch (error) {
-        const maybePrismaError = error as { code?: string; message?: string };
-        const isRetryableTxnConflict =
-          maybePrismaError.code === 'P2034' ||
-          maybePrismaError.message?.includes('write conflict') ||
-          maybePrismaError.message?.includes('deadlock') ||
-          maybePrismaError.message?.includes('serialization');
-
-        if (!isRetryableTxnConflict || attempt === WorkspaceDefaultsService.defaultWorkspaceRetryDelaysMs.length - 1) {
+        if (
+          !WorkspaceDefaultsService.isRetryableTransactionConflict(error) ||
+          attempt === WorkspaceDefaultsService.serializableRetryDelaysMs.length - 1
+        ) {
           const membership = await this.prisma.workspaceMembership.findFirst({
             where: { userId: sub },
             include: { workspace: true },
@@ -66,7 +72,7 @@ export class WorkspaceDefaultsService {
           return membership.workspace;
         }
 
-        const delayMs = WorkspaceDefaultsService.defaultWorkspaceRetryDelaysMs[attempt];
+        const delayMs = WorkspaceDefaultsService.serializableRetryDelaysMs[attempt];
         await new Promise((resolve) => setTimeout(resolve, delayMs));
       }
     }
@@ -75,9 +81,31 @@ export class WorkspaceDefaultsService {
   }
 
   async ensureProjectDefaults(projectId: string, actor: string, correlationId: string) {
-    await this.prisma.$transaction(async (tx) => {
-      await this.ensureProjectDefaultsInTx(tx, projectId, actor, correlationId);
-    });
+    for (let attempt = 0; attempt < WorkspaceDefaultsService.serializableRetryDelaysMs.length; attempt += 1) {
+      try {
+        await this.prisma.$transaction(
+          async (tx) => {
+            await this.ensureProjectDefaultsInTx(tx, projectId, actor, correlationId);
+          },
+          {
+            maxWait: 5000,
+            timeout: 10000,
+            isolationLevel: 'Serializable',
+          },
+        );
+        return;
+      } catch (error) {
+        if (
+          !WorkspaceDefaultsService.isRetryableTransactionConflict(error) ||
+          attempt === WorkspaceDefaultsService.serializableRetryDelaysMs.length - 1
+        ) {
+          throw error;
+        }
+
+        const delayMs = WorkspaceDefaultsService.serializableRetryDelaysMs[attempt];
+        await new Promise((resolve) => setTimeout(resolve, delayMs));
+      }
+    }
   }
 
   async ensureProjectDefaultsInTx(

--- a/apps/core-api/src/common/workspace-defaults.service.ts
+++ b/apps/core-api/src/common/workspace-defaults.service.ts
@@ -75,56 +75,9 @@ export class WorkspaceDefaultsService {
   }
 
   async ensureProjectDefaults(projectId: string, actor: string, correlationId: string) {
-    const tx = this.prisma;
-    const defaultSection = await tx.section.findFirst({ where: { projectId, isDefault: true } });
-    if (!defaultSection) {
-      const section = await tx.section.create({
-        data: { projectId, name: 'No Section', isDefault: true, position: 1000 },
-      });
-      await this.auditOutbox.appendAuditOutbox({
-        tx,
-        actor,
-        entityType: 'Section',
-        entityId: section.id,
-        action: 'section.created.default',
-        afterJson: section,
-        correlationId,
-        outboxType: 'section.created',
-        payload: section,
-      });
-    }
-
-    const templates = [
-      { name: 'Progress to Done', templateKey: 'progress_to_done' },
-      { name: 'Progress to In Progress', templateKey: 'progress_to_in_progress' },
-    ] as const;
-    for (const tpl of templates) {
-      const rule = await tx.rule.upsert({
-        where: { projectId_templateKey: { projectId, templateKey: tpl.templateKey } },
-        create: {
-          projectId,
-          name: tpl.name,
-          templateKey: tpl.templateKey,
-          definition: templateDefinition(tpl.templateKey) as Prisma.InputJsonValue,
-          enabled: true,
-          cooldownSec: 60,
-        },
-        update: {
-          definition: templateDefinition(tpl.templateKey) as Prisma.InputJsonValue,
-        },
-      });
-      await this.auditOutbox.appendAuditOutbox({
-        tx,
-        actor,
-        entityType: 'Rule',
-        entityId: rule.id,
-        action: 'rule.ensure_template',
-        afterJson: rule,
-        correlationId,
-        outboxType: 'rule.created',
-        payload: rule,
-      });
-    }
+    await this.prisma.$transaction(async (tx) => {
+      await this.ensureProjectDefaultsInTx(tx, projectId, actor, correlationId);
+    });
   }
 
   async ensureProjectDefaultsInTx(
@@ -156,14 +109,27 @@ export class WorkspaceDefaultsService {
       { name: 'Progress to In Progress', templateKey: 'progress_to_in_progress' },
     ] as const;
     for (const tpl of templates) {
+      const definition = templateDefinition(tpl.templateKey) as Prisma.InputJsonValue;
       const existing = await tx.rule.findUnique({
         where: { projectId_templateKey: { projectId, templateKey: tpl.templateKey } },
       });
       if (existing) {
-        if (!existing.definition) {
-          await tx.rule.update({
+        if (JSON.stringify(existing.definition) !== JSON.stringify(definition)) {
+          const rule = await tx.rule.update({
             where: { id: existing.id },
-            data: { definition: templateDefinition(tpl.templateKey) as Prisma.InputJsonValue },
+            data: { definition },
+          });
+          await this.auditOutbox.appendAuditOutbox({
+            tx,
+            actor,
+            entityType: 'Rule',
+            entityId: rule.id,
+            action: 'rule.ensure_template',
+            beforeJson: existing,
+            afterJson: rule,
+            correlationId,
+            outboxType: 'rule.updated',
+            payload: rule,
           });
         }
         continue;
@@ -173,7 +139,7 @@ export class WorkspaceDefaultsService {
           projectId,
           name: tpl.name,
           templateKey: tpl.templateKey,
-          definition: templateDefinition(tpl.templateKey) as Prisma.InputJsonValue,
+          definition,
           enabled: true,
           cooldownSec: 60,
         },

--- a/apps/core-api/src/custom-fields/custom-fields.controller.ts
+++ b/apps/core-api/src/custom-fields/custom-fields.controller.ts
@@ -27,8 +27,9 @@ import {
 import { Type } from 'class-transformer';
 import { CustomFieldType, Prisma, ProjectRole } from '@prisma/client';
 import { AuthGuard } from '../auth/auth.guard';
+import { AuditOutboxService } from '../common/audit-outbox.service';
+import { AuthorizationService } from '../common/authorization.service';
 import { PrismaService } from '../prisma/prisma.service';
-import { DomainService } from '../common/domain.service';
 import { CurrentRequest } from '../common/current-request';
 import type { AppRequest } from '../common/types';
 import { parseCustomFieldDefinition } from './custom-field.validation';
@@ -125,7 +126,8 @@ type FieldWithOptions = Prisma.CustomFieldDefinitionGetPayload<{
 export class CustomFieldsController {
   constructor(
     @Inject(PrismaService) private readonly prisma: PrismaService,
-    @Inject(DomainService) private readonly domain: DomainService,
+    @Inject(AuditOutboxService) private readonly auditOutbox: AuditOutboxService,
+    @Inject(AuthorizationService) private readonly authorization: AuthorizationService,
   ) {}
 
   @Get('projects/:id/custom-fields')
@@ -134,7 +136,7 @@ export class CustomFieldsController {
     @Query('includeArchived') includeArchivedRaw: string | undefined,
     @CurrentRequest() req: AppRequest,
   ) {
-    await this.domain.requireProjectRole(projectId, req.user.sub, ProjectRole.VIEWER);
+    await this.authorization.requireProjectRole(projectId, req.user.sub, ProjectRole.VIEWER);
     const includeArchived = includeArchivedRaw === 'true';
 
     const fields = await this.prisma.customFieldDefinition.findMany({
@@ -160,7 +162,7 @@ export class CustomFieldsController {
     @Body() body: CreateCustomFieldDto,
     @CurrentRequest() req: AppRequest,
   ) {
-    await this.domain.requireProjectRole(projectId, req.user.sub, ProjectRole.MEMBER);
+    await this.authorization.requireProjectRole(projectId, req.user.sub, ProjectRole.MEMBER);
     const parsed = parseCustomFieldDefinition(body);
 
     return this.prisma.$transaction(async (tx) => {
@@ -192,7 +194,7 @@ export class CustomFieldsController {
         include: { options: { orderBy: [{ position: 'asc' }, { createdAt: 'asc' }] } },
       });
 
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor: req.user.sub,
         entityType: 'CustomFieldDefinition',
@@ -225,7 +227,7 @@ export class CustomFieldsController {
       throw new ConflictException('Archived custom fields cannot be updated');
     }
 
-    await this.domain.requireProjectRole(existing.projectId, req.user.sub, ProjectRole.MEMBER);
+    await this.authorization.requireProjectRole(existing.projectId, req.user.sub, ProjectRole.MEMBER);
 
     const activeExistingOptions = existing.options.filter((option) => !option.archivedAt);
     const targetType = body.type ?? existing.type;
@@ -278,7 +280,7 @@ export class CustomFieldsController {
         },
       });
 
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor: req.user.sub,
         entityType: 'CustomFieldDefinition',
@@ -304,7 +306,7 @@ export class CustomFieldsController {
     if (!existing) {
       throw new NotFoundException('Custom field definition not found');
     }
-    await this.domain.requireProjectRole(existing.projectId, req.user.sub, ProjectRole.MEMBER);
+    await this.authorization.requireProjectRole(existing.projectId, req.user.sub, ProjectRole.MEMBER);
 
     if (existing.archivedAt) {
       return { ok: true };
@@ -322,7 +324,7 @@ export class CustomFieldsController {
         data: { archivedAt },
       });
 
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor: req.user.sub,
         entityType: 'CustomFieldDefinition',

--- a/apps/core-api/src/forms/forms.controller.ts
+++ b/apps/core-api/src/forms/forms.controller.ts
@@ -25,8 +25,9 @@ import {
 } from 'class-validator';
 import { Type } from 'class-transformer';
 import { AuthGuard } from '../auth/auth.guard';
+import { AuditOutboxService } from '../common/audit-outbox.service';
+import { AuthorizationService } from '../common/authorization.service';
 import { PrismaService } from '../prisma/prisma.service';
-import { DomainService } from '../common/domain.service';
 import { CurrentRequest } from '../common/current-request';
 import type { AppRequest } from '../common/types';
 import { ProjectRole, FormQuestionType, Prisma } from '@prisma/client';
@@ -139,7 +140,8 @@ class ListFormsQuery {
 export class FormsController {
   constructor(
     @Inject(PrismaService) private readonly prisma: PrismaService,
-    @Inject(DomainService) private readonly domain: DomainService,
+    @Inject(AuditOutboxService) private readonly auditOutbox: AuditOutboxService,
+    @Inject(AuthorizationService) private readonly authorization: AuthorizationService,
   ) {}
 
   private logPublicFormSubmission(
@@ -167,7 +169,7 @@ export class FormsController {
     @Body() body: CreateFormDto,
     @CurrentRequest() req: AppRequest,
   ) {
-    await this.domain.requireProjectRole(projectId, req.user.sub, ProjectRole.MEMBER);
+    await this.authorization.requireProjectRole(projectId, req.user.sub, ProjectRole.MEMBER);
 
     const trimmedTitle = body.title.trim();
     if (!trimmedTitle) {
@@ -189,7 +191,7 @@ export class FormsController {
         },
       });
 
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor: req.user.sub,
         entityType: 'Form',
@@ -212,7 +214,7 @@ export class FormsController {
     @Query() query: ListFormsQuery,
     @CurrentRequest() req: AppRequest,
   ) {
-    await this.domain.requireProjectRole(projectId, req.user.sub, ProjectRole.MEMBER);
+    await this.authorization.requireProjectRole(projectId, req.user.sub, ProjectRole.MEMBER);
 
     const includeArchived = query.includeArchived === 'true';
     const forms = await this.prisma.form.findMany({
@@ -256,7 +258,7 @@ export class FormsController {
       throw new NotFoundException('Form not found');
     }
 
-    await this.domain.requireProjectRole(form.projectId, req.user.sub, ProjectRole.MEMBER);
+    await this.authorization.requireProjectRole(form.projectId, req.user.sub, ProjectRole.MEMBER);
 
     return form;
   }
@@ -276,7 +278,7 @@ export class FormsController {
       throw new NotFoundException('Form not found');
     }
 
-    await this.domain.requireProjectRole(form.projectId, req.user.sub, ProjectRole.MEMBER);
+    await this.authorization.requireProjectRole(form.projectId, req.user.sub, ProjectRole.MEMBER);
 
     const data: Prisma.FormUpdateInput = {};
     if (body.title !== undefined) {
@@ -305,7 +307,7 @@ export class FormsController {
         },
       });
 
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor: req.user.sub,
         entityType: 'Form',
@@ -336,7 +338,7 @@ export class FormsController {
       throw new NotFoundException('Form not found');
     }
 
-    await this.domain.requireProjectRole(form.projectId, req.user.sub, ProjectRole.MEMBER);
+    await this.authorization.requireProjectRole(form.projectId, req.user.sub, ProjectRole.MEMBER);
 
     return this.prisma.$transaction(async (tx) => {
       const updated = await tx.form.update({
@@ -344,7 +346,7 @@ export class FormsController {
         data: { archivedAt: new Date() },
       });
 
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor: req.user.sub,
         entityType: 'Form',
@@ -376,7 +378,7 @@ export class FormsController {
       throw new NotFoundException('Form not found');
     }
 
-    await this.domain.requireProjectRole(form.projectId, req.user.sub, ProjectRole.MEMBER);
+    await this.authorization.requireProjectRole(form.projectId, req.user.sub, ProjectRole.MEMBER);
 
     const trimmedLabel = body.label.trim();
     if (!trimmedLabel) {
@@ -427,7 +429,7 @@ export class FormsController {
       throw new NotFoundException('Question not found');
     }
 
-    await this.domain.requireProjectRole(question.form.projectId, req.user.sub, ProjectRole.MEMBER);
+    await this.authorization.requireProjectRole(question.form.projectId, req.user.sub, ProjectRole.MEMBER);
 
     const data: Prisma.FormQuestionUpdateInput = {};
     if (body.type !== undefined) data.type = body.type;
@@ -460,7 +462,7 @@ export class FormsController {
       throw new NotFoundException('Question not found');
     }
 
-    await this.domain.requireProjectRole(question.form.projectId, req.user.sub, ProjectRole.MEMBER);
+    await this.authorization.requireProjectRole(question.form.projectId, req.user.sub, ProjectRole.MEMBER);
 
     await this.prisma.formQuestion.delete({
       where: { id: questionId },
@@ -503,7 +505,7 @@ export class FormsController {
       if (!req.user?.sub) {
         throw new ConflictException('Authentication required for non-public forms');
       }
-      await this.domain.requireProjectRole(form.projectId, req.user.sub, ProjectRole.MEMBER);
+      await this.authorization.requireProjectRole(form.projectId, req.user.sub, ProjectRole.MEMBER);
     }
 
     if (form.isPublic && body.website?.trim()) {
@@ -600,7 +602,7 @@ export class FormsController {
         data: { createdTaskId: task.id },
       });
 
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor: req.user?.sub ?? `anonymous:${body.submitterEmail}`,
         entityType: 'FormSubmission',
@@ -639,7 +641,7 @@ export class FormsController {
       throw new NotFoundException('Form not found');
     }
 
-    await this.domain.requireProjectRole(form.projectId, req.user.sub, ProjectRole.MEMBER);
+    await this.authorization.requireProjectRole(form.projectId, req.user.sub, ProjectRole.MEMBER);
 
     const submissions = await this.prisma.formSubmission.findMany({
       where: { formId },

--- a/apps/core-api/src/goals/goals.module.ts
+++ b/apps/core-api/src/goals/goals.module.ts
@@ -1,14 +1,13 @@
 import { Module } from '@nestjs/common';
 import { AuthModule } from '../auth/auth.module';
-import { DomainService } from '../common/domain.service';
-import { PrismaService } from '../prisma/prisma.service';
+import { CommonServicesModule } from '../common/common-services.module';
 import { GoalsController } from './goals.controller';
 import { GoalsService } from './goals.service';
 
 @Module({
-  imports: [AuthModule],
+  imports: [AuthModule, CommonServicesModule],
   controllers: [GoalsController],
-  providers: [GoalsService, PrismaService, DomainService],
+  providers: [GoalsService],
   exports: [GoalsService],
 })
 export class GoalsModule {}

--- a/apps/core-api/src/goals/goals.service.ts
+++ b/apps/core-api/src/goals/goals.service.ts
@@ -6,7 +6,8 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { GoalStatus, Prisma, ProjectRole, ProjectStatusHealth, WorkspaceRole } from '@prisma/client';
-import { DomainService } from '../common/domain.service';
+import { AuditOutboxService } from '../common/audit-outbox.service';
+import { AuthorizationService } from '../common/authorization.service';
 import { PrismaService } from '../prisma/prisma.service';
 
 type GoalRecord = {
@@ -36,7 +37,8 @@ const DEFAULT_GOAL_HISTORY_TAKE = 100;
 export class GoalsService {
   constructor(
     @Inject(PrismaService) private readonly prisma: PrismaService,
-    @Inject(DomainService) private readonly domain: DomainService,
+    @Inject(AuditOutboxService) private readonly auditOutbox: AuditOutboxService,
+    @Inject(AuthorizationService) private readonly authorization: AuthorizationService,
   ) {}
 
   async createGoal(
@@ -51,7 +53,7 @@ export class GoalsService {
       progressPercent?: number;
     },
   ) {
-    await this.domain.requireWorkspaceRole(workspaceId, actorUserId, WorkspaceRole.WS_MEMBER);
+    await this.authorization.requireWorkspaceRole(workspaceId, actorUserId, WorkspaceRole.WS_MEMBER);
     const ownerUserId = input.ownerUserId ?? actorUserId;
     await this.requireWorkspaceOwner(workspaceId, ownerUserId);
 
@@ -67,7 +69,7 @@ export class GoalsService {
         },
       });
 
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor: actorUserId,
         entityType: 'Goal',
@@ -84,7 +86,7 @@ export class GoalsService {
   }
 
   async listGoals(workspaceId: string, actorUserId: string, includeArchived: boolean) {
-    await this.domain.requireWorkspaceMembership(workspaceId, actorUserId);
+    await this.authorization.requireWorkspaceMembership(workspaceId, actorUserId);
     const goals = await this.prisma.goal.findMany({
       where: {
         workspaceId,
@@ -176,7 +178,7 @@ export class GoalsService {
         },
       });
 
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor: actorUserId,
         entityType: 'Goal',
@@ -209,7 +211,7 @@ export class GoalsService {
         data: { deletedAt: new Date() },
       });
 
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor: actorUserId,
         entityType: 'Goal',
@@ -309,7 +311,7 @@ export class GoalsService {
               data: { goalId, projectId },
             });
 
-        await this.domain.appendAuditOutbox({
+        await this.auditOutbox.appendAuditOutbox({
           tx,
           actor: actorUserId,
           entityType: 'GoalProjectLink',
@@ -363,7 +365,7 @@ export class GoalsService {
         data: { deletedAt: new Date() },
       });
 
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor: actorUserId,
         entityType: 'GoalProjectLink',
@@ -422,7 +424,7 @@ export class GoalsService {
     if (!goal) {
       throw new NotFoundException('goal not found');
     }
-    await this.domain.requireWorkspaceRole(goal.workspaceId, actorUserId, options?.minRole ?? WorkspaceRole.WS_MEMBER);
+    await this.authorization.requireWorkspaceRole(goal.workspaceId, actorUserId, options?.minRole ?? WorkspaceRole.WS_MEMBER);
     if (options?.requireActive && goal.archivedAt) {
       throw new ConflictException('goal is archived');
     }
@@ -431,7 +433,7 @@ export class GoalsService {
 
   private async requireWorkspaceOwner(workspaceId: string, ownerUserId: string) {
     try {
-      await this.domain.requireWorkspaceMembership(workspaceId, ownerUserId);
+      await this.authorization.requireWorkspaceMembership(workspaceId, ownerUserId);
     } catch (error) {
       if (error instanceof NotFoundException) {
         throw new BadRequestException('goal owner must be a workspace member');
@@ -441,7 +443,7 @@ export class GoalsService {
   }
 
   private async requireProject(projectId: string, actorUserId: string, minRole: ProjectRole) {
-    await this.domain.requireProjectRole(projectId, actorUserId, minRole);
+    await this.authorization.requireProjectRole(projectId, actorUserId, minRole);
     const project = await this.prisma.project.findUnique({
       where: { id: projectId },
       select: { id: true, workspaceId: true },
@@ -533,7 +535,7 @@ export class GoalsService {
       },
     });
 
-    await this.domain.appendAuditOutbox({
+    await this.auditOutbox.appendAuditOutbox({
       tx,
       actor: actorUserId,
       entityType: 'Goal',

--- a/apps/core-api/src/guest-access/guest-access.controller.ts
+++ b/apps/core-api/src/guest-access/guest-access.controller.ts
@@ -3,8 +3,9 @@ import { IsEmail, IsEnum, IsInt, IsOptional, Max, Min } from 'class-validator';
 import { createHash, randomBytes } from 'node:crypto';
 import { GuestAccessScopeType, GuestAccessStatus, ProjectRole } from '@prisma/client';
 import { AuthGuard } from '../auth/auth.guard';
+import { AuditOutboxService } from '../common/audit-outbox.service';
+import { AuthorizationService } from '../common/authorization.service';
 import { CurrentRequest } from '../common/current-request';
-import { DomainService } from '../common/domain.service';
 import type { AppRequest } from '../common/types';
 import { ProjectRoleGuard, RequireProjectRole, WorkspaceRoleGuard } from '../auth/role.guard';
 import { evaluateGuestInvitationState, isGuestProjectRole } from './guest-access.contract';
@@ -29,7 +30,8 @@ class CreateGuestInvitationDto {
 export class GuestAccessController {
   constructor(
     @Inject(PrismaService) private readonly prisma: PrismaService,
-    @Inject(DomainService) private readonly domain: DomainService,
+    @Inject(AuditOutboxService) private readonly auditOutbox: AuditOutboxService,
+    @Inject(AuthorizationService) private readonly authorization: AuthorizationService,
   ) {}
 
   @Get('projects/:id/guest-access')
@@ -116,7 +118,7 @@ export class GuestAccessController {
           createdByUserId: req.user.sub,
         },
       });
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor: req.user.sub,
         entityType: 'GuestInvitation',
@@ -154,7 +156,7 @@ export class GuestAccessController {
       throw new BadRequestException('Workspace-scoped guest invitations are not supported by this endpoint');
     }
 
-    await this.domain.requireProjectRole(invitation.projectId, req.user.sub, ProjectRole.ADMIN);
+    await this.authorization.requireProjectRole(invitation.projectId, req.user.sub, ProjectRole.ADMIN);
 
     return this.prisma.$transaction(async (tx) => {
       const revokedAt = new Date();
@@ -176,7 +178,7 @@ export class GuestAccessController {
         },
       });
 
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor: req.user.sub,
         entityType: 'GuestInvitation',

--- a/apps/core-api/src/integrations/github.provider.ts
+++ b/apps/core-api/src/integrations/github.provider.ts
@@ -17,8 +17,8 @@ import {
 import { GithubApiService } from './github-api.service';
 import { GithubProviderSettings, type GithubIssue } from './github.types';
 import { IntegrationCredentialsService } from './integration-credentials.service';
+import { AuditOutboxService } from '../common/audit-outbox.service';
 import { PrismaService } from '../prisma/prisma.service';
-import { DomainService } from '../common/domain.service';
 import {
   IntegrationCredentialKind,
   IntegrationMappingDirection,
@@ -40,7 +40,7 @@ export class GithubIntegrationProvider implements IntegrationProvider {
 
   constructor(
     @Inject(PrismaService) private readonly prisma: PrismaService,
-    @Inject(DomainService) private readonly domain: DomainService,
+    @Inject(AuditOutboxService) private readonly auditOutbox: AuditOutboxService,
     @Inject(GithubApiService) private readonly githubApi: GithubApiService,
     @Inject(IntegrationCredentialsService)
     private readonly credentials: IntegrationCredentialsService,
@@ -206,7 +206,7 @@ export class GithubIntegrationProvider implements IntegrationProvider {
             metadata,
           },
         });
-        await this.domain.appendAuditOutbox({
+        await this.auditOutbox.appendAuditOutbox({
           tx,
           actor: input.actorUserId,
           entityType: 'Task',
@@ -251,7 +251,7 @@ export class GithubIntegrationProvider implements IntegrationProvider {
           metadata,
         },
       });
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor: input.actorUserId,
         entityType: 'Task',

--- a/apps/core-api/src/integrations/integrations.module.ts
+++ b/apps/core-api/src/integrations/integrations.module.ts
@@ -1,7 +1,6 @@
 import { Module } from '@nestjs/common';
 import { AuthModule } from '../auth/auth.module';
-import { DomainService } from '../common/domain.service';
-import { PrismaService } from '../prisma/prisma.service';
+import { CommonServicesModule } from '../common/common-services.module';
 import { INTEGRATION_PROVIDERS, IntegrationProviderRegistry } from './integration-provider.registry';
 import { IntegrationRuntimeService } from './integration-runtime.service';
 import { GithubApiService } from './github-api.service';
@@ -14,11 +13,9 @@ import { SlackWebhookController } from './slack.controller';
 import { SlackIntegrationProvider } from './slack.provider';
 
 @Module({
-  imports: [AuthModule],
+  imports: [AuthModule, CommonServicesModule],
   controllers: [SlackWebhookController, IntegrationsController],
   providers: [
-    PrismaService,
-    DomainService,
     GithubApiService,
     IntegrationCredentialsService,
     IntegrationsService,

--- a/apps/core-api/src/integrations/integrations.service.ts
+++ b/apps/core-api/src/integrations/integrations.service.ts
@@ -6,8 +6,9 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { IntegrationCredentialKind, IntegrationProviderKind, WorkspaceRole } from '@prisma/client';
+import { AuditOutboxService } from '../common/audit-outbox.service';
+import { AuthorizationService } from '../common/authorization.service';
 import { PrismaService } from '../prisma/prisma.service';
-import { DomainService } from '../common/domain.service';
 import { IntegrationRuntimeService, type RunIntegrationSyncJobResult } from './integration-runtime.service';
 import { IntegrationCredentialsService } from './integration-credentials.service';
 import { Prisma } from '@prisma/client';
@@ -29,7 +30,8 @@ type GithubConnectInput = {
 export class IntegrationsService {
   constructor(
     @Inject(PrismaService) private readonly prisma: PrismaService,
-    @Inject(DomainService) private readonly domain: DomainService,
+    @Inject(AuditOutboxService) private readonly auditOutbox: AuditOutboxService,
+    @Inject(AuthorizationService) private readonly authorization: AuthorizationService,
     @Inject(IntegrationRuntimeService)
     private readonly runtime: IntegrationRuntimeService,
     @Inject(IntegrationCredentialsService)
@@ -37,7 +39,7 @@ export class IntegrationsService {
   ) {}
 
   async listWorkspaceIntegrations(workspaceId: string, actorUserId: string) {
-    await this.domain.requireWorkspaceMembership(workspaceId, actorUserId);
+    await this.authorization.requireWorkspaceMembership(workspaceId, actorUserId);
     const configs = await this.prisma.integrationProviderConfig.findMany({
       where: { workspaceId },
       include: {
@@ -58,7 +60,7 @@ export class IntegrationsService {
   }
 
   async connectGithub(input: GithubConnectInput) {
-    await this.domain.requireWorkspaceRole(input.workspaceId, input.actorUserId, WorkspaceRole.WS_ADMIN);
+    await this.authorization.requireWorkspaceRole(input.workspaceId, input.actorUserId, WorkspaceRole.WS_ADMIN);
 
     const project = await this.prisma.project.findUnique({
       where: { id: input.projectId },
@@ -96,7 +98,7 @@ export class IntegrationsService {
 
     const refreshed = await this.getConfigOrThrow(providerConfig.id, input.workspaceId);
     await this.prisma.$transaction(async (tx) => {
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor: input.actorUserId,
         entityType: 'IntegrationProviderConfig',
@@ -124,7 +126,7 @@ export class IntegrationsService {
     correlationId: string;
     scope: string;
   }) {
-    await this.domain.requireWorkspaceRole(input.workspaceId, input.actorUserId, WorkspaceRole.WS_ADMIN);
+    await this.authorization.requireWorkspaceRole(input.workspaceId, input.actorUserId, WorkspaceRole.WS_ADMIN);
     const config = await this.getConfigOrThrow(input.providerConfigId, input.workspaceId);
     const providerKey = this.mapProviderKey(config.provider);
     let result: RunIntegrationSyncJobResult;
@@ -142,7 +144,7 @@ export class IntegrationsService {
       const syncError = this.serializeSyncError(error);
 
       await this.prisma.$transaction(async (tx) => {
-        await this.domain.appendAuditOutbox({
+        await this.auditOutbox.appendAuditOutbox({
           tx,
           actor: input.actorUserId,
           entityType: 'IntegrationProviderConfig',
@@ -171,7 +173,7 @@ export class IntegrationsService {
 
     if (result.status === 'completed') {
       await this.prisma.$transaction(async (tx) => {
-        await this.domain.appendAuditOutbox({
+        await this.auditOutbox.appendAuditOutbox({
           tx,
           actor: input.actorUserId,
           entityType: 'IntegrationProviderConfig',

--- a/apps/core-api/src/notifications/notifications.controller.ts
+++ b/apps/core-api/src/notifications/notifications.controller.ts
@@ -10,10 +10,10 @@ import {
 } from '@nestjs/common';
 import { IsBoolean, IsIn, IsOptional, IsString } from 'class-validator';
 import { AuthGuard } from '../auth/auth.guard';
+import { AuditOutboxService } from '../common/audit-outbox.service';
 import { CurrentRequest } from '../common/current-request';
 import type { AppRequest } from '../common/types';
 import { PrismaService } from '../prisma/prisma.service';
-import { DomainService } from '../common/domain.service';
 import { NotificationsService } from './notifications.service';
 import { normalizeInboxNotificationType } from './notification-taxonomy';
 
@@ -38,7 +38,7 @@ class MarkNotificationReadBody {
 export class NotificationsController {
   constructor(
     @Inject(PrismaService) private readonly prisma: PrismaService,
-    @Inject(DomainService) private readonly domain: DomainService,
+    @Inject(AuditOutboxService) private readonly auditOutbox: AuditOutboxService,
     @Inject(NotificationsService) private readonly notifications: NotificationsService,
   ) {}
 
@@ -79,7 +79,7 @@ export class NotificationsController {
     await this.prisma.$transaction(async (tx) => {
       const ids = unread.map((item) => item.id);
       await tx.inboxNotification.updateMany({ where: { id: { in: ids } }, data: { readAt: now } });
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor: req.user.sub,
         entityType: 'User',
@@ -115,7 +115,7 @@ export class NotificationsController {
         where: { id: existing.id },
         data: { readAt: read ? new Date() : null },
       });
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor: req.user.sub,
         entityType: 'InboxNotification',

--- a/apps/core-api/src/notifications/notifications.service.ts
+++ b/apps/core-api/src/notifications/notifications.service.ts
@@ -1,7 +1,7 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { Prisma, ProjectRole } from '@prisma/client';
+import { AuditOutboxService } from '../common/audit-outbox.service';
 import { PrismaService } from '../prisma/prisma.service';
-import { DomainService } from '../common/domain.service';
 import {
   InboxNotificationType,
   NOTIFICATION_TYPE_APPROVAL_APPROVED,
@@ -19,7 +19,7 @@ import {
 export class NotificationsService {
   constructor(
     @Inject(PrismaService) private readonly prisma: PrismaService,
-    @Inject(DomainService) private readonly domain: DomainService,
+    @Inject(AuditOutboxService) private readonly auditOutbox: AuditOutboxService,
   ) {}
 
   private async upsertNotification(
@@ -69,7 +69,7 @@ export class NotificationsService {
           readAt: null,
         },
       });
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor: input.actor,
         entityType: 'InboxNotification',
@@ -103,7 +103,7 @@ export class NotificationsService {
         triggeredByUserId: input.triggeredByUserId,
       },
     });
-    await this.domain.appendAuditOutbox({
+    await this.auditOutbox.appendAuditOutbox({
       tx,
       actor: input.actor,
       entityType: 'InboxNotification',

--- a/apps/core-api/src/portfolios/portfolios.module.ts
+++ b/apps/core-api/src/portfolios/portfolios.module.ts
@@ -1,13 +1,12 @@
 import { Module } from '@nestjs/common';
 import { AuthModule } from '../auth/auth.module';
-import { DomainService } from '../common/domain.service';
-import { PrismaService } from '../prisma/prisma.service';
+import { CommonServicesModule } from '../common/common-services.module';
 import { PortfoliosService } from './portfolios.service';
 import { PortfoliosController } from './portfolios.controller';
 
 @Module({
-  imports: [AuthModule],
+  imports: [AuthModule, CommonServicesModule],
   controllers: [PortfoliosController],
-  providers: [PrismaService, DomainService, PortfoliosService],
+  providers: [PortfoliosService],
 })
 export class PortfoliosModule {}

--- a/apps/core-api/src/portfolios/portfolios.service.ts
+++ b/apps/core-api/src/portfolios/portfolios.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, NotFoundException, ForbiddenException } from '@nestjs/common';
+import { AuthorizationService } from '../common/authorization.service';
 import { PrismaService } from '../prisma/prisma.service';
-import { DomainService } from '../common/domain.service';
 
 export interface CreatePortfolioDto {
   name: string;
@@ -27,12 +27,12 @@ export interface PortfolioProgress {
 export class PortfoliosService {
   constructor(
     private readonly prisma: PrismaService,
-    private readonly domain: DomainService,
+    private readonly authorization: AuthorizationService,
   ) {}
 
   async createPortfolio(workspaceId: string, userId: string, dto: CreatePortfolioDto) {
     // Verify user is workspace member
-    await this.domain.requireWorkspaceMembership(workspaceId, userId);
+    await this.authorization.requireWorkspaceMembership(workspaceId, userId);
 
     // Validate projectIds belong to workspace
     if (dto.projectIds && dto.projectIds.length > 0) {
@@ -74,7 +74,7 @@ export class PortfoliosService {
 
   async getPortfolios(workspaceId: string, userId: string) {
     // Verify user is workspace member
-    await this.domain.requireWorkspaceMembership(workspaceId, userId);
+    await this.authorization.requireWorkspaceMembership(workspaceId, userId);
 
     const portfolios = await this.prisma.portfolio.findMany({
       where: { workspaceId },
@@ -106,7 +106,7 @@ export class PortfoliosService {
 
   async getPortfolio(workspaceId: string, portfolioId: string, userId: string) {
     // Verify user is workspace member
-    await this.domain.requireWorkspaceMembership(workspaceId, userId);
+    await this.authorization.requireWorkspaceMembership(workspaceId, userId);
 
     const portfolio = await this.prisma.portfolio.findFirst({
       where: { id: portfolioId, workspaceId },
@@ -161,7 +161,7 @@ export class PortfoliosService {
     dto: UpdatePortfolioDto,
   ) {
     // Verify user is workspace member
-    await this.domain.requireWorkspaceMembership(workspaceId, userId);
+    await this.authorization.requireWorkspaceMembership(workspaceId, userId);
 
     const portfolio = await this.prisma.portfolio.findFirst({
       where: { id: portfolioId, workspaceId },
@@ -189,7 +189,7 @@ export class PortfoliosService {
 
   async deletePortfolio(workspaceId: string, portfolioId: string, userId: string) {
     // Verify user is workspace member
-    await this.domain.requireWorkspaceMembership(workspaceId, userId);
+    await this.authorization.requireWorkspaceMembership(workspaceId, userId);
 
     const portfolio = await this.prisma.portfolio.findFirst({
       where: { id: portfolioId, workspaceId },
@@ -213,7 +213,7 @@ export class PortfoliosService {
     userId: string,
   ) {
     // Verify user is workspace member
-    await this.domain.requireWorkspaceMembership(workspaceId, userId);
+    await this.authorization.requireWorkspaceMembership(workspaceId, userId);
 
     // Verify portfolio exists
     const portfolio = await this.prisma.portfolio.findFirst({
@@ -274,7 +274,7 @@ export class PortfoliosService {
     userId: string,
   ) {
     // Verify user is workspace member
-    await this.domain.requireWorkspaceMembership(workspaceId, userId);
+    await this.authorization.requireWorkspaceMembership(workspaceId, userId);
 
     // Verify portfolio exists
     const portfolio = await this.prisma.portfolio.findFirst({

--- a/apps/core-api/src/projects/project-status-updates.controller.ts
+++ b/apps/core-api/src/projects/project-status-updates.controller.ts
@@ -22,8 +22,9 @@ import {
 } from 'class-validator';
 import { Type } from 'class-transformer';
 import { AuthGuard } from '../auth/auth.guard';
+import { AuditOutboxService } from '../common/audit-outbox.service';
+import { AuthorizationService } from '../common/authorization.service';
 import { PrismaService } from '../prisma/prisma.service';
-import { DomainService } from '../common/domain.service';
 import { CurrentRequest } from '../common/current-request';
 import type { AppRequest } from '../common/types';
 import { NotificationsService } from '../notifications/notifications.service';
@@ -67,7 +68,8 @@ class ListStatusUpdatesQuery {
 export class ProjectStatusUpdatesController {
   constructor(
     @Inject(PrismaService) private readonly prisma: PrismaService,
-    @Inject(DomainService) private readonly domain: DomainService,
+    @Inject(AuditOutboxService) private readonly auditOutbox: AuditOutboxService,
+    @Inject(AuthorizationService) private readonly authorization: AuthorizationService,
     @Inject(NotificationsService) private readonly notifications: NotificationsService,
     @Inject(GoalsService) private readonly goalsService: GoalsService,
   ) {}
@@ -93,7 +95,7 @@ export class ProjectStatusUpdatesController {
     const blockers = this.normalizeListItems(body.blockers, 'blockers');
     const nextSteps = this.normalizeListItems(body.nextSteps, 'nextSteps');
 
-    await this.domain.requireProjectRole(projectId, req.user.sub, ProjectRole.MEMBER);
+    await this.authorization.requireProjectRole(projectId, req.user.sub, ProjectRole.MEMBER);
 
     return this.prisma.$transaction(async (tx) => {
       const mentionedUserIds = await this.resolveMentionedProjectMemberIds(tx, projectId, [
@@ -121,7 +123,7 @@ export class ProjectStatusUpdatesController {
         },
       });
 
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor: req.user.sub,
         entityType: 'ProjectStatusUpdate',
@@ -178,7 +180,7 @@ export class ProjectStatusUpdatesController {
     @Query() query: ListStatusUpdatesQuery,
     @CurrentRequest() req: AppRequest,
   ) {
-    await this.domain.requireProjectRole(projectId, req.user.sub, ProjectRole.VIEWER);
+    await this.authorization.requireProjectRole(projectId, req.user.sub, ProjectRole.VIEWER);
 
     const take = query.take ?? 20;
 
@@ -216,7 +218,7 @@ export class ProjectStatusUpdatesController {
     @Param('id') projectId: string,
     @CurrentRequest() req: AppRequest,
   ) {
-    await this.domain.requireProjectRole(projectId, req.user.sub, ProjectRole.VIEWER);
+    await this.authorization.requireProjectRole(projectId, req.user.sub, ProjectRole.VIEWER);
 
     const statusUpdate = await this.prisma.projectStatusUpdate.findFirst({
       where: { projectId },
@@ -241,7 +243,7 @@ export class ProjectStatusUpdatesController {
     @Param('statusUpdateId') statusUpdateId: string,
     @CurrentRequest() req: AppRequest,
   ) {
-    await this.domain.requireProjectRole(projectId, req.user.sub, ProjectRole.VIEWER);
+    await this.authorization.requireProjectRole(projectId, req.user.sub, ProjectRole.VIEWER);
 
     const statusUpdate = await this.prisma.projectStatusUpdate.findFirst({
       where: {

--- a/apps/core-api/src/projects/project-views.controller.ts
+++ b/apps/core-api/src/projects/project-views.controller.ts
@@ -29,7 +29,8 @@ import {
   type ProjectViewState,
 } from '@atlaspm/domain';
 import { AuthGuard } from '../auth/auth.guard';
-import { DomainService } from '../common/domain.service';
+import { AuditOutboxService } from '../common/audit-outbox.service';
+import { AuthorizationService } from '../common/authorization.service';
 import { CurrentRequest } from '../common/current-request';
 import type { AppRequest } from '../common/types';
 import { PrismaService } from '../prisma/prisma.service';
@@ -80,12 +81,13 @@ type ProjectViewValidationContext = {
 export class ProjectViewsController {
   constructor(
     @Inject(PrismaService) private readonly prisma: PrismaService,
-    @Inject(DomainService) private readonly domain: DomainService,
+    @Inject(AuditOutboxService) private readonly auditOutbox: AuditOutboxService,
+    @Inject(AuthorizationService) private readonly authorization: AuthorizationService,
   ) {}
 
   @Get('projects/:id/saved-views')
   async list(@Param('id') projectId: string, @CurrentRequest() req: AppRequest) {
-    await this.domain.requireProjectRole(projectId, req.user.sub, ProjectRole.VIEWER);
+    await this.authorization.requireProjectRole(projectId, req.user.sub, ProjectRole.VIEWER);
     return this.buildSavedViewsResponse(projectId, req.user.sub);
   }
 
@@ -96,7 +98,7 @@ export class ProjectViewsController {
     @Body() body: PutProjectViewDefaultDto,
     @CurrentRequest() req: AppRequest,
   ) {
-    await this.domain.requireProjectRole(projectId, req.user.sub, ProjectRole.VIEWER);
+    await this.authorization.requireProjectRole(projectId, req.user.sub, ProjectRole.VIEWER);
     const mode = this.parseProjectViewMode(rawMode);
 
     await this.prisma.$transaction(async (tx) => {
@@ -134,7 +136,7 @@ export class ProjectViewsController {
         },
       });
 
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor: req.user.sub,
         entityType: 'ProjectViewPreference',
@@ -163,7 +165,7 @@ export class ProjectViewsController {
     @Body() body: CreateProjectSavedViewDto,
     @CurrentRequest() req: AppRequest,
   ) {
-    await this.domain.requireProjectRole(projectId, req.user.sub, ProjectRole.VIEWER);
+    await this.authorization.requireProjectRole(projectId, req.user.sub, ProjectRole.VIEWER);
     const mode = this.parseProjectViewMode(body.mode);
     const name = this.normalizeSavedViewName(body.name);
 
@@ -184,7 +186,7 @@ export class ProjectViewsController {
         },
       });
 
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor: req.user.sub,
         entityType: 'ProjectSavedView',
@@ -207,7 +209,7 @@ export class ProjectViewsController {
     @CurrentRequest() req: AppRequest,
   ) {
     const existing = await this.getOwnedSavedViewOrThrow(viewId, req.user.sub);
-    await this.domain.requireProjectRole(existing.projectId, req.user.sub, ProjectRole.VIEWER);
+    await this.authorization.requireProjectRole(existing.projectId, req.user.sub, ProjectRole.VIEWER);
     const mode = this.parseProjectViewMode(existing.mode);
 
     return this.prisma.$transaction(async (tx) => {
@@ -224,7 +226,7 @@ export class ProjectViewsController {
         },
       });
 
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor: req.user.sub,
         entityType: 'ProjectSavedView',
@@ -244,11 +246,11 @@ export class ProjectViewsController {
   @Delete('saved-views/:id')
   async remove(@Param('id') viewId: string, @CurrentRequest() req: AppRequest) {
     const existing = await this.getOwnedSavedViewOrThrow(viewId, req.user.sub);
-    await this.domain.requireProjectRole(existing.projectId, req.user.sub, ProjectRole.VIEWER);
+    await this.authorization.requireProjectRole(existing.projectId, req.user.sub, ProjectRole.VIEWER);
 
     return this.prisma.$transaction(async (tx) => {
       await tx.projectSavedView.delete({ where: { id: existing.id } });
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor: req.user.sub,
         entityType: 'ProjectSavedView',

--- a/apps/core-api/src/projects/projects.controller.ts
+++ b/apps/core-api/src/projects/projects.controller.ts
@@ -3,10 +3,11 @@ import { GuestAccessScopeType, GuestAccessStatus, Prisma, ProjectRole, Workspace
 import { IsEnum, IsString, IsUUID } from 'class-validator';
 import { AuthGuard } from '../auth/auth.guard';
 import { PrismaService } from '../prisma/prisma.service';
-import { DomainService } from '../common/domain.service';
+import { AuditOutboxService } from '../common/audit-outbox.service';
 import { CurrentRequest } from '../common/current-request';
 import type { AppRequest } from '../common/types';
 import { ProjectRoleGuard, RequireProjectRole, RequireWorkspaceRole, WorkspaceRoleGuard } from '../auth/role.guard';
+import { WorkspaceDefaultsService } from '../common/workspace-defaults.service';
 
 class CreateProjectDto {
   @IsUUID()
@@ -34,7 +35,8 @@ class UpdateProjectMemberDto {
 export class ProjectsController {
   constructor(
     @Inject(PrismaService) private readonly prisma: PrismaService,
-    @Inject(DomainService) private readonly domain: DomainService,
+    @Inject(AuditOutboxService) private readonly auditOutbox: AuditOutboxService,
+    @Inject(WorkspaceDefaultsService) private readonly defaults: WorkspaceDefaultsService,
   ) {}
 
   @Get()
@@ -80,7 +82,7 @@ export class ProjectsController {
       await tx.projectMembership.create({
         data: { projectId: project.id, userId: req.user.sub, role: ProjectRole.ADMIN },
       });
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor: req.user.sub,
         entityType: 'Project',
@@ -91,7 +93,7 @@ export class ProjectsController {
         outboxType: 'project.created',
         payload: project,
       });
-      await this.domain.ensureProjectDefaultsInTx(tx, project.id, req.user.sub, req.correlationId);
+      await this.defaults.ensureProjectDefaultsInTx(tx, project.id, req.user.sub, req.correlationId);
       return project;
     });
     return this.hydrateProjectWithFollowerState(project, req.user.sub);
@@ -131,7 +133,7 @@ export class ProjectsController {
         const follower = await tx.projectFollower.create({
           data: { projectId, userId: req.user.sub },
         });
-        await this.domain.appendAuditOutbox({
+        await this.auditOutbox.appendAuditOutbox({
           tx,
           actor: req.user.sub,
           entityType: 'ProjectFollower',
@@ -172,7 +174,7 @@ export class ProjectsController {
       });
       if (existing) {
         await tx.projectFollower.delete({ where: { id: existing.id } });
-        await this.domain.appendAuditOutbox({
+        await this.auditOutbox.appendAuditOutbox({
           tx,
           actor: req.user.sub,
           entityType: 'ProjectFollower',
@@ -234,7 +236,7 @@ export class ProjectsController {
         create: { projectId, userId: body.userId, role: body.role },
         update: { role: body.role },
       });
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor: req.user.sub,
         entityType: 'ProjectMembership',
@@ -265,7 +267,7 @@ export class ProjectsController {
         where: { id: existing.id },
         data: { role: body.role },
       });
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor: req.user.sub,
         entityType: 'ProjectMembership',
@@ -293,7 +295,7 @@ export class ProjectsController {
         where: { projectId_userId: { projectId, userId } },
       });
       await tx.projectMembership.delete({ where: { id: existing.id } });
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor: req.user.sub,
         entityType: 'ProjectMembership',

--- a/apps/core-api/src/recurring-tasks/recurring-task.worker.ts
+++ b/apps/core-api/src/recurring-tasks/recurring-task.worker.ts
@@ -1,6 +1,6 @@
 import { Injectable, Inject, Logger, OnModuleInit, OnModuleDestroy } from '@nestjs/common';
+import { AuditOutboxService } from '../common/audit-outbox.service';
 import { PrismaService } from '../prisma/prisma.service';
-import { DomainService } from '../common/domain.service';
 import { RecurringFrequency, TaskStatus } from '@prisma/client';
 import {
   calculateNextScheduledAtAfter,
@@ -20,7 +20,7 @@ export class RecurringTaskWorker implements OnModuleInit, OnModuleDestroy {
 
   constructor(
     @Inject(PrismaService) private readonly prisma: PrismaService,
-    @Inject(DomainService) private readonly domain: DomainService,
+    @Inject(AuditOutboxService) private readonly auditOutbox: AuditOutboxService,
   ) {}
 
   onModuleInit() {
@@ -208,7 +208,7 @@ export class RecurringTaskWorker implements OnModuleInit, OnModuleDestroy {
           },
         });
 
-        await this.domain.appendAuditOutbox({
+        await this.auditOutbox.appendAuditOutbox({
           tx,
           actor: 'system:recurring-worker',
           entityType: 'RecurringTaskGeneration',
@@ -347,7 +347,7 @@ export class RecurringTaskWorker implements OnModuleInit, OnModuleDestroy {
           },
         });
 
-        await this.domain.appendAuditOutbox({
+        await this.auditOutbox.appendAuditOutbox({
           tx,
           actor: 'system:recurring-worker',
           entityType: 'RecurringTaskGeneration',
@@ -474,7 +474,7 @@ export class RecurringTaskWorker implements OnModuleInit, OnModuleDestroy {
             },
           });
 
-          await this.domain.appendAuditOutbox({
+          await this.auditOutbox.appendAuditOutbox({
             tx,
             actor: 'system:recurring-worker',
             entityType: 'RecurringTaskGeneration',

--- a/apps/core-api/src/recurring-tasks/recurring-tasks.controller.ts
+++ b/apps/core-api/src/recurring-tasks/recurring-tasks.controller.ts
@@ -29,8 +29,9 @@ import {
 } from 'class-validator';
 import { Type } from 'class-transformer';
 import { AuthGuard } from '../auth/auth.guard';
+import { AuditOutboxService } from '../common/audit-outbox.service';
+import { AuthorizationService } from '../common/authorization.service';
 import { PrismaService } from '../prisma/prisma.service';
-import { DomainService } from '../common/domain.service';
 import { CurrentRequest } from '../common/current-request';
 import type { AppRequest } from '../common/types';
 import { Prisma, ProjectRole, RecurringFrequency, Priority } from '@prisma/client';
@@ -170,7 +171,8 @@ class ListRecurringRulesQuery {
 export class RecurringTasksController {
   constructor(
     @Inject(PrismaService) private readonly prisma: PrismaService,
-    @Inject(DomainService) private readonly domain: DomainService,
+    @Inject(AuditOutboxService) private readonly auditOutbox: AuditOutboxService,
+    @Inject(AuthorizationService) private readonly authorization: AuthorizationService,
   ) {}
 
   @Post('projects/:id/recurring-rules')
@@ -179,7 +181,7 @@ export class RecurringTasksController {
     @Body() body: CreateRecurringRuleDto,
     @CurrentRequest() req: AppRequest,
   ) {
-    await this.domain.requireProjectRole(projectId, req.user.sub, ProjectRole.MEMBER);
+    await this.authorization.requireProjectRole(projectId, req.user.sub, ProjectRole.MEMBER);
 
     const trimmedTitle = body.title.trim();
     if (!trimmedTitle) {
@@ -242,7 +244,7 @@ export class RecurringTasksController {
           },
         });
 
-        await this.domain.appendAuditOutbox({
+        await this.auditOutbox.appendAuditOutbox({
           tx,
           actor: req.user.sub,
           entityType: 'RecurringRule',
@@ -275,7 +277,7 @@ export class RecurringTasksController {
     @Query() query: ListRecurringRulesQuery,
     @CurrentRequest() req: AppRequest,
   ) {
-    await this.domain.requireProjectRole(projectId, req.user.sub, ProjectRole.MEMBER);
+    await this.authorization.requireProjectRole(projectId, req.user.sub, ProjectRole.MEMBER);
 
     const includeInactive = query.includeInactive === 'true';
     const rules = await this.prisma.recurringRule.findMany({
@@ -312,7 +314,7 @@ export class RecurringTasksController {
       throw new NotFoundException('Recurring rule not found');
     }
 
-    await this.domain.requireProjectRole(rule.projectId, req.user.sub, ProjectRole.MEMBER);
+    await this.authorization.requireProjectRole(rule.projectId, req.user.sub, ProjectRole.MEMBER);
 
     return rule;
   }
@@ -335,7 +337,7 @@ export class RecurringTasksController {
       throw new NotFoundException('Recurring rule not found');
     }
 
-    await this.domain.requireProjectRole(rule.projectId, req.user.sub, ProjectRole.MEMBER);
+    await this.authorization.requireProjectRole(rule.projectId, req.user.sub, ProjectRole.MEMBER);
 
     if (body.title !== undefined) {
       const trimmedTitle = body.title.trim();
@@ -407,7 +409,7 @@ export class RecurringTasksController {
         data,
       });
 
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor: req.user.sub,
         entityType: 'RecurringRule',
@@ -443,14 +445,14 @@ export class RecurringTasksController {
       throw new NotFoundException('Recurring rule not found');
     }
 
-    await this.domain.requireProjectRole(rule.projectId, req.user.sub, ProjectRole.MEMBER);
+    await this.authorization.requireProjectRole(rule.projectId, req.user.sub, ProjectRole.MEMBER);
 
     return this.prisma.$transaction(async (tx) => {
       await tx.recurringRule.delete({
         where: { id: ruleId },
       });
 
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor: req.user.sub,
         entityType: 'RecurringRule',

--- a/apps/core-api/src/rules/rules.controller.ts
+++ b/apps/core-api/src/rules/rules.controller.ts
@@ -1,6 +1,8 @@
 import { BadRequestException, Body, ConflictException, Controller, Delete, Get, Inject, NotFoundException, Param, Patch, Post, UseGuards } from '@nestjs/common';
 import { IsBoolean, IsInt, IsOptional, IsString, Min } from 'class-validator';
 import { AuthGuard } from '../auth/auth.guard';
+import { AuditOutboxService } from '../common/audit-outbox.service';
+import { AuthorizationService } from '../common/authorization.service';
 import { PrismaService } from '../prisma/prisma.service';
 import { DomainService } from '../common/domain.service';
 import { CurrentRequest } from '../common/current-request';
@@ -47,6 +49,8 @@ class PatchRuleDto {
 @UseGuards(AuthGuard, ProjectRoleGuard)
 export class RulesController {
   constructor(
+    @Inject(AuditOutboxService) private readonly auditOutbox: AuditOutboxService,
+    @Inject(AuthorizationService) private readonly authorization: AuthorizationService,
     @Inject(PrismaService) private readonly prisma: PrismaService,
     @Inject(DomainService) private readonly domain: DomainService,
   ) {}
@@ -74,7 +78,7 @@ export class RulesController {
           cooldownSec: body.cooldownSec ?? 60,
         },
       });
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor: req.user.sub,
         entityType: 'Rule',
@@ -92,7 +96,7 @@ export class RulesController {
   @Patch('rules/:id')
   async patch(@Param('id') id: string, @Body() body: PatchRuleDto, @CurrentRequest() req: AppRequest) {
     const rule = await this.prisma.rule.findUniqueOrThrow({ where: { id } });
-    await this.domain.requireProjectRole(rule.projectId, req.user.sub, ProjectRole.MEMBER);
+    await this.authorization.requireProjectRole(rule.projectId, req.user.sub, ProjectRole.MEMBER);
     const definition = body.definition ? parseRuleDefinition(body.definition) : undefined;
     this.ensureDefinitionHasConditions(definition);
 
@@ -105,7 +109,7 @@ export class RulesController {
           definition: definition as Prisma.InputJsonValue | undefined,
         },
       });
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor: req.user.sub,
         entityType: 'Rule',
@@ -133,10 +137,10 @@ export class RulesController {
 
   private async setEnabled(id: string, enabled: boolean, req: AppRequest) {
     const rule = await this.prisma.rule.findUniqueOrThrow({ where: { id } });
-    await this.domain.requireProjectRole(rule.projectId, req.user.sub, ProjectRole.MEMBER);
+    await this.authorization.requireProjectRole(rule.projectId, req.user.sub, ProjectRole.MEMBER);
     return this.prisma.$transaction(async (tx) => {
       const updated = await tx.rule.update({ where: { id }, data: { enabled } });
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor: req.user.sub,
         entityType: 'Rule',
@@ -159,7 +163,7 @@ export class RulesController {
       throw new NotFoundException('Rule not found');
     }
 
-    await this.domain.requireProjectRole(rule.projectId, req.user.sub, ProjectRole.MEMBER);
+    await this.authorization.requireProjectRole(rule.projectId, req.user.sub, ProjectRole.MEMBER);
 
     if (rule.templateKey && this.domain.isDefaultRuleTemplateKey(rule.templateKey)) {
       throw new ConflictException({
@@ -170,7 +174,7 @@ export class RulesController {
 
     return this.prisma.$transaction(async (tx) => {
       await tx.rule.delete({ where: { id } });
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor: req.user.sub,
         entityType: 'Rule',

--- a/apps/core-api/src/sections/sections.controller.ts
+++ b/apps/core-api/src/sections/sections.controller.ts
@@ -11,8 +11,9 @@ import {
 } from '@nestjs/common';
 import { IsArray, IsString, IsUUID } from 'class-validator';
 import { AuthGuard } from '../auth/auth.guard';
+import { AuditOutboxService } from '../common/audit-outbox.service';
+import { AuthorizationService } from '../common/authorization.service';
 import { PrismaService } from '../prisma/prisma.service';
-import { DomainService } from '../common/domain.service';
 import { CurrentRequest } from '../common/current-request';
 import type { AppRequest } from '../common/types';
 import { ProjectRole } from '@prisma/client';
@@ -42,7 +43,8 @@ class ReorderSectionDto {
 export class SectionsController {
   constructor(
     @Inject(PrismaService) private readonly prisma: PrismaService,
-    @Inject(DomainService) private readonly domain: DomainService,
+    @Inject(AuditOutboxService) private readonly auditOutbox: AuditOutboxService,
+    @Inject(AuthorizationService) private readonly authorization: AuthorizationService,
   ) {}
 
   @Get('projects/:id/sections')
@@ -63,7 +65,7 @@ export class SectionsController {
       const section = await tx.section.create({
         data: { projectId, name: body.name, position: (last?.position ?? 0) + 1000 },
       });
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor: req.user.sub,
         entityType: 'Section',
@@ -81,11 +83,11 @@ export class SectionsController {
   @Patch('sections/:id')
   async patch(@Param('id') id: string, @Body() body: PatchSectionDto, @CurrentRequest() req: AppRequest) {
     const section = await this.prisma.section.findUniqueOrThrow({ where: { id } });
-    await this.domain.requireProjectRole(section.projectId, req.user.sub, ProjectRole.MEMBER);
+    await this.authorization.requireProjectRole(section.projectId, req.user.sub, ProjectRole.MEMBER);
 
     return this.prisma.$transaction(async (tx) => {
       const updated = await tx.section.update({ where: { id }, data: { name: body.name } });
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor: req.user.sub,
         entityType: 'Section',
@@ -114,7 +116,7 @@ export class SectionsController {
       for (const [i, sectionId] of body.orderedSectionIds.entries()) {
         await tx.section.update({ where: { id: sectionId }, data: { position: (i + 1) * 1000 } });
       }
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor: req.user.sub,
         entityType: 'Section',

--- a/apps/core-api/src/task-approvals/task-approval.controller.ts
+++ b/apps/core-api/src/task-approvals/task-approval.controller.ts
@@ -1,8 +1,9 @@
 import { Controller, Post, Get, Param, Body, UseGuards, NotFoundException, ConflictException, Inject } from '@nestjs/common';
 import { AuthGuard } from '../auth/auth.guard';
+import { AuditOutboxService } from '../common/audit-outbox.service';
+import { AuthorizationService } from '../common/authorization.service';
 import { CurrentRequest } from '../common/current-request';
 import type { AppRequest } from '../common/types';
-import { DomainService } from '../common/domain.service';
 import { PrismaService } from '../prisma/prisma.service';
 import { Prisma, ProjectRole, TaskStatus, TaskType } from '@prisma/client';
 import { IsEnum, IsOptional, IsString } from 'class-validator';
@@ -32,7 +33,8 @@ class RespondApprovalDto {
 export class TaskApprovalController {
   constructor(
     @Inject(PrismaService) private readonly prisma: PrismaService,
-    @Inject(DomainService) private readonly domain: DomainService,
+    @Inject(AuditOutboxService) private readonly auditOutbox: AuditOutboxService,
+    @Inject(AuthorizationService) private readonly authorization: AuthorizationService,
     @Inject(NotificationsService) private readonly notifications: NotificationsService,
   ) {}
 
@@ -50,7 +52,7 @@ export class TaskApprovalController {
       throw new NotFoundException('Task not found');
     }
 
-    await this.domain.requireProjectRole(task.projectId, req.user.sub, ProjectRole.VIEWER);
+    await this.authorization.requireProjectRole(task.projectId, req.user.sub, ProjectRole.VIEWER);
 
     return task.approval;
   }
@@ -74,7 +76,7 @@ export class TaskApprovalController {
       throw new ConflictException('Task is not an approval type');
     }
 
-    await this.domain.requireProjectRole(task.projectId, req.user.sub, ProjectRole.MEMBER);
+    await this.authorization.requireProjectRole(task.projectId, req.user.sub, ProjectRole.MEMBER);
 
     if (task.approval?.status === 'PENDING') {
       throw new ConflictException('Approval request already pending');
@@ -109,7 +111,7 @@ export class TaskApprovalController {
         include: { approver: { select: { id: true, displayName: true } } },
       });
 
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor: req.user.sub,
         entityType: 'TaskApproval',
@@ -169,7 +171,7 @@ export class TaskApprovalController {
     }
 
     if (task.approval.approverUserId !== req.user.sub) {
-      await this.domain.requireProjectRole(task.projectId, req.user.sub, ProjectRole.ADMIN);
+      await this.authorization.requireProjectRole(task.projectId, req.user.sub, ProjectRole.ADMIN);
     }
 
     const trimmedComment = body.comment?.trim() || null;
@@ -187,7 +189,7 @@ export class TaskApprovalController {
 
       const beforeApproval = task.approval;
 
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor: req.user.sub,
         entityType: 'TaskApproval',
@@ -207,7 +209,7 @@ export class TaskApprovalController {
           data: { status: TaskStatus.DONE, completedAt: new Date() },
         });
 
-        await this.domain.appendAuditOutbox({
+        await this.auditOutbox.appendAuditOutbox({
           tx,
           actor: req.user.sub,
           entityType: 'Task',
@@ -266,14 +268,14 @@ export class TaskApprovalController {
       throw new NotFoundException('No approval request found');
     }
 
-    await this.domain.requireProjectRole(task.projectId, req.user.sub, ProjectRole.MEMBER);
+    await this.authorization.requireProjectRole(task.projectId, req.user.sub, ProjectRole.MEMBER);
 
     await this.prisma.$transaction(async (tx: Prisma.TransactionClient) => {
       const deletedApproval = await tx.taskApproval.delete({
         where: { taskId },
       });
 
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor: req.user.sub,
         entityType: 'TaskApproval',

--- a/apps/core-api/src/task-project-links/task-project-links.module.ts
+++ b/apps/core-api/src/task-project-links/task-project-links.module.ts
@@ -1,13 +1,12 @@
 import { Module } from '@nestjs/common';
 import { AuthModule } from '../auth/auth.module';
-import { DomainService } from '../common/domain.service';
-import { PrismaService } from '../prisma/prisma.service';
+import { CommonServicesModule } from '../common/common-services.module';
 import { TaskProjectLinksController } from './task-project-links.controller';
 import { TaskProjectLinksService } from './task-project-links.service';
 
 @Module({
-  imports: [AuthModule],
+  imports: [AuthModule, CommonServicesModule],
   controllers: [TaskProjectLinksController],
-  providers: [PrismaService, DomainService, TaskProjectLinksService],
+  providers: [TaskProjectLinksService],
 })
 export class TaskProjectLinksModule {}

--- a/apps/core-api/src/task-project-links/task-project-links.service.ts
+++ b/apps/core-api/src/task-project-links/task-project-links.service.ts
@@ -1,6 +1,7 @@
 import { BadRequestException, ConflictException, Inject, Injectable, NotFoundException } from '@nestjs/common';
 import { Prisma, ProjectRole } from '@prisma/client';
-import { DomainService } from '../common/domain.service';
+import { AuditOutboxService } from '../common/audit-outbox.service';
+import { AuthorizationService } from '../common/authorization.service';
 import { PrismaService } from '../prisma/prisma.service';
 
 type TaskWithProject = {
@@ -16,7 +17,8 @@ type TaskWithProject = {
 export class TaskProjectLinksService {
   constructor(
     @Inject(PrismaService) private readonly prisma: PrismaService,
-    @Inject(DomainService) private readonly domain: DomainService,
+    @Inject(AuditOutboxService) private readonly auditOutbox: AuditOutboxService,
+    @Inject(AuthorizationService) private readonly authorization: AuthorizationService,
   ) {}
 
   async listTaskProjects(taskId: string, actorUserId: string) {
@@ -70,7 +72,7 @@ export class TaskProjectLinksService {
             },
           });
 
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor: actorUserId,
         entityType: 'Task',
@@ -115,7 +117,7 @@ export class TaskProjectLinksService {
         data: { deletedAt: new Date() },
       });
 
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor: actorUserId,
         entityType: 'Task',
@@ -171,7 +173,7 @@ export class TaskProjectLinksService {
         data: { projectId },
       });
 
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor: actorUserId,
         entityType: 'Task',
@@ -212,12 +214,12 @@ export class TaskProjectLinksService {
       throw new NotFoundException('task not found');
     }
 
-    await this.domain.requireProjectRole(task.projectId, actorUserId, minRole);
+    await this.authorization.requireProjectRole(task.projectId, actorUserId, minRole);
     return task;
   }
 
   private async requireProjectWithRole(projectId: string, actorUserId: string, minRole: ProjectRole) {
-    await this.domain.requireProjectRole(projectId, actorUserId, minRole);
+    await this.authorization.requireProjectRole(projectId, actorUserId, minRole);
     const project = await this.prisma.project.findUnique({
       where: { id: projectId },
       select: { id: true, workspaceId: true },

--- a/apps/core-api/src/task-time-tracking/task-time-tracking.controller.ts
+++ b/apps/core-api/src/task-time-tracking/task-time-tracking.controller.ts
@@ -1,8 +1,9 @@
 import { Controller, Get, Post, Patch, Delete, Param, Body, UseGuards, NotFoundException, Inject } from '@nestjs/common';
 import { AuthGuard } from '../auth/auth.guard';
+import { AuditOutboxService } from '../common/audit-outbox.service';
+import { AuthorizationService } from '../common/authorization.service';
 import { CurrentRequest } from '../common/current-request';
 import type { AppRequest } from '../common/types';
-import { DomainService } from '../common/domain.service';
 import { PrismaService } from '../prisma/prisma.service';
 import { Prisma, ProjectRole } from '@prisma/client';
 import { IsInt, IsOptional, IsString, Min } from 'class-validator';
@@ -39,7 +40,8 @@ class UpdateEstimateDto {
 export class TaskTimeTrackingController {
   constructor(
     @Inject(PrismaService) private readonly prisma: PrismaService,
-    @Inject(DomainService) private readonly domain: DomainService,
+    @Inject(AuditOutboxService) private readonly auditOutbox: AuditOutboxService,
+    @Inject(AuthorizationService) private readonly authorization: AuthorizationService,
   ) {}
 
   @Get('tasks/:id/time-logs')
@@ -55,7 +57,7 @@ export class TaskTimeTrackingController {
       throw new NotFoundException('Task not found');
     }
 
-    await this.domain.requireProjectRole(task.projectId, req.user.sub, ProjectRole.VIEWER);
+    await this.authorization.requireProjectRole(task.projectId, req.user.sub, ProjectRole.VIEWER);
 
     return this.prisma.taskTimeLog.findMany({
       where: { taskId },
@@ -78,7 +80,7 @@ export class TaskTimeTrackingController {
       throw new NotFoundException('Task not found');
     }
 
-    await this.domain.requireProjectRole(task.projectId, req.user.sub, ProjectRole.MEMBER);
+    await this.authorization.requireProjectRole(task.projectId, req.user.sub, ProjectRole.MEMBER);
 
     return this.prisma.$transaction(async (tx: Prisma.TransactionClient) => {
       const timeLog = await tx.taskTimeLog.create({
@@ -96,7 +98,7 @@ export class TaskTimeTrackingController {
         data: { spentMinutes: { increment: body.minutes } },
       });
 
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor: req.user.sub,
         entityType: 'TaskTimeLog',
@@ -131,7 +133,7 @@ export class TaskTimeTrackingController {
     }
 
     const requiredRole = timeLog.userId === req.user.sub ? ProjectRole.MEMBER : ProjectRole.ADMIN;
-    await this.domain.requireProjectRole(timeLog.task.projectId, req.user.sub, requiredRole);
+    await this.authorization.requireProjectRole(timeLog.task.projectId, req.user.sub, requiredRole);
 
     return this.prisma.$transaction(async (tx: Prisma.TransactionClient) => {
       const minutesDiff = (body.minutes ?? timeLog.minutes) - timeLog.minutes;
@@ -152,7 +154,7 @@ export class TaskTimeTrackingController {
         });
       }
 
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor: req.user.sub,
         entityType: 'TaskTimeLog',
@@ -187,7 +189,7 @@ export class TaskTimeTrackingController {
     }
 
     const requiredRole = timeLog.userId === req.user.sub ? ProjectRole.MEMBER : ProjectRole.ADMIN;
-    await this.domain.requireProjectRole(timeLog.task.projectId, req.user.sub, requiredRole);
+    await this.authorization.requireProjectRole(timeLog.task.projectId, req.user.sub, requiredRole);
 
     await this.prisma.$transaction(async (tx: Prisma.TransactionClient) => {
       await tx.taskTimeLog.delete({ where: { id } });
@@ -197,7 +199,7 @@ export class TaskTimeTrackingController {
         data: { spentMinutes: { decrement: timeLog.minutes } },
       });
 
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor: req.user.sub,
         entityType: 'TaskTimeLog',
@@ -228,7 +230,7 @@ export class TaskTimeTrackingController {
       throw new NotFoundException('Task not found');
     }
 
-    await this.domain.requireProjectRole(task.projectId, req.user.sub, ProjectRole.MEMBER);
+    await this.authorization.requireProjectRole(task.projectId, req.user.sub, ProjectRole.MEMBER);
 
     return this.prisma.$transaction(async (tx: Prisma.TransactionClient) => {
       const updated = await tx.task.update({
@@ -236,7 +238,7 @@ export class TaskTimeTrackingController {
         data: { estimateMinutes: body.estimateMinutes },
       });
 
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor: req.user.sub,
         entityType: 'Task',
@@ -258,7 +260,7 @@ export class TaskTimeTrackingController {
     @Param('id') projectId: string,
     @CurrentRequest() req: AppRequest,
   ) {
-    await this.domain.requireProjectRole(projectId, req.user.sub, ProjectRole.VIEWER);
+    await this.authorization.requireProjectRole(projectId, req.user.sub, ProjectRole.VIEWER);
 
     const [taskAgg, userAgg] = await Promise.all([
       this.prisma.taskTimeLog.groupBy({

--- a/apps/core-api/src/tasks/reminder-delivery.service.ts
+++ b/apps/core-api/src/tasks/reminder-delivery.service.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable, Logger, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
 import { UserStatus } from '@prisma/client';
-import { DomainService } from '../common/domain.service';
+import { AuditOutboxService } from '../common/audit-outbox.service';
 import { PrismaService } from '../prisma/prisma.service';
 
 @Injectable()
@@ -11,7 +11,7 @@ export class ReminderDeliveryService implements OnModuleInit, OnModuleDestroy {
 
   constructor(
     @Inject(PrismaService) private readonly prisma: PrismaService,
-    @Inject(DomainService) private readonly domain: DomainService,
+    @Inject(AuditOutboxService) private readonly auditOutbox: AuditOutboxService,
   ) {}
 
   onModuleInit() {
@@ -79,7 +79,7 @@ export class ReminderDeliveryService implements OnModuleInit, OnModuleDestroy {
         });
         if (!claim.count) return false;
 
-        await this.domain.appendAuditOutbox({
+        await this.auditOutbox.appendAuditOutbox({
           tx,
           actor: 'reminder-worker',
           entityType: 'Task',

--- a/apps/core-api/src/tasks/subtask.service.ts
+++ b/apps/core-api/src/tasks/subtask.service.ts
@@ -1,8 +1,8 @@
 import { BadRequestException, ConflictException, Injectable, Inject, Logger } from '@nestjs/common';
+import { AuditOutboxService } from '../common/audit-outbox.service';
 import { PrismaService } from '../prisma/prisma.service';
 import { CycleDetectionService } from './cycle-detection.service';
 import { Prisma, DependencyType, type Task } from '@prisma/client';
-import { DomainService } from '../common/domain.service';
 
 export interface SubtaskTreeNode extends Task {
   children: SubtaskTreeNode[];
@@ -29,7 +29,7 @@ export class SubtaskService {
   constructor(
     @Inject(PrismaService) private readonly prisma: PrismaService,
     @Inject(CycleDetectionService) private readonly cycleDetection: CycleDetectionService,
-    @Inject(DomainService) private readonly domain: DomainService,
+    @Inject(AuditOutboxService) private readonly auditOutbox: AuditOutboxService,
   ) {}
 
   /**
@@ -221,7 +221,7 @@ export class SubtaskService {
           createdAt: dependency.createdAt,
         };
 
-        await this.domain.appendAuditOutbox({
+        await this.auditOutbox.appendAuditOutbox({
           tx,
           actor,
           entityType: 'TaskDependency',
@@ -289,7 +289,7 @@ export class SubtaskService {
           where: { taskId_dependsOnId: { taskId, dependsOnId } },
         });
 
-        await this.domain.appendAuditOutbox({
+        await this.auditOutbox.appendAuditOutbox({
           tx,
           actor,
           entityType: 'TaskDependency',

--- a/apps/core-api/src/tasks/task-attachments.service.ts
+++ b/apps/core-api/src/tasks/task-attachments.service.ts
@@ -9,7 +9,8 @@ import { Prisma, ProjectRole } from '@prisma/client';
 import { promises as fs } from 'node:fs';
 import { randomBytes, randomUUID } from 'node:crypto';
 import { dirname } from 'node:path';
-import { DomainService } from '../common/domain.service';
+import { AuditOutboxService } from '../common/audit-outbox.service';
+import { AuthorizationService } from '../common/authorization.service';
 import type { AppRequest } from '../common/types';
 import { PrismaService } from '../prisma/prisma.service';
 import { AttachmentDownloadUrlService } from './attachment-download-url.service';
@@ -22,14 +23,15 @@ const IMAGE_MIME_ALLOWLIST = new Set(['image/png', 'image/jpeg', 'image/webp', '
 export class TaskAttachmentsService {
   constructor(
     @Inject(PrismaService) private readonly prisma: PrismaService,
-    @Inject(DomainService) private readonly domain: DomainService,
+    @Inject(AuditOutboxService) private readonly auditOutbox: AuditOutboxService,
+    @Inject(AuthorizationService) private readonly authorization: AuthorizationService,
     @Inject(AttachmentDownloadUrlService)
     private readonly attachmentDownloadUrls: AttachmentDownloadUrlService,
   ) {}
 
   async listAttachments(taskId: string, includeDeletedRaw: string | undefined, req: AppRequest) {
     const task = await this.prisma.task.findFirstOrThrow({ where: { id: taskId, deletedAt: null } });
-    await this.domain.requireProjectRole(task.projectId, req.user.sub, ProjectRole.VIEWER);
+    await this.authorization.requireProjectRole(task.projectId, req.user.sub, ProjectRole.VIEWER);
     const includeDeleted = String(includeDeletedRaw ?? '').toLowerCase() === 'true';
     const where: Prisma.TaskAttachmentWhereInput = {
       taskId,
@@ -49,7 +51,7 @@ export class TaskAttachmentsService {
     req: AppRequest,
   ) {
     const task = await this.prisma.task.findFirstOrThrow({ where: { id: taskId, deletedAt: null } });
-    await this.domain.requireProjectRole(task.projectId, req.user.sub, ProjectRole.MEMBER);
+    await this.authorization.requireProjectRole(task.projectId, req.user.sub, ProjectRole.MEMBER);
     if (!IMAGE_MIME_ALLOWLIST.has(body.mimeType)) {
       throw new ConflictException('Unsupported image mime type');
     }
@@ -72,7 +74,7 @@ export class TaskAttachmentsService {
           uploadToken,
         },
       });
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor: req.user.sub,
         entityType: 'Task',
@@ -104,7 +106,7 @@ export class TaskAttachmentsService {
       where: { id },
       include: { task: true },
     });
-    await this.domain.requireProjectRole(attachment.task.projectId, req.user.sub, ProjectRole.MEMBER);
+    await this.authorization.requireProjectRole(attachment.task.projectId, req.user.sub, ProjectRole.MEMBER);
     if (!attachment.uploadToken || attachment.uploadToken !== token) {
       throw new ForbiddenException('Invalid upload token');
     }
@@ -139,7 +141,7 @@ export class TaskAttachmentsService {
 
   async completeAttachment(taskId: string, attachmentId: string, req: AppRequest) {
     const task = await this.prisma.task.findFirstOrThrow({ where: { id: taskId, deletedAt: null } });
-    await this.domain.requireProjectRole(task.projectId, req.user.sub, ProjectRole.MEMBER);
+    await this.authorization.requireProjectRole(task.projectId, req.user.sub, ProjectRole.MEMBER);
     const attachment = await this.prisma.taskAttachment.findUniqueOrThrow({
       where: { id: attachmentId },
     });
@@ -167,7 +169,7 @@ export class TaskAttachmentsService {
         where: { id: current.id },
         data: { completedAt: new Date(), uploadToken: accessToken, sizeBytes: Number(stat.size) },
       });
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor: req.user.sub,
         entityType: 'Task',
@@ -187,14 +189,14 @@ export class TaskAttachmentsService {
       where: { id },
       include: { task: true },
     });
-    await this.domain.requireProjectRole(attachment.task.projectId, req.user.sub, ProjectRole.MEMBER);
+    await this.authorization.requireProjectRole(attachment.task.projectId, req.user.sub, ProjectRole.MEMBER);
     if (attachment.deletedAt) return this.serializeAttachment(attachment);
     return this.prisma.$transaction(async (tx) => {
       const deleted = await tx.taskAttachment.update({
         where: { id },
         data: { deletedAt: new Date() },
       });
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor: req.user.sub,
         entityType: 'Task',
@@ -215,14 +217,14 @@ export class TaskAttachmentsService {
       where: { id },
       include: { task: true },
     });
-    await this.domain.requireProjectRole(attachment.task.projectId, req.user.sub, ProjectRole.MEMBER);
+    await this.authorization.requireProjectRole(attachment.task.projectId, req.user.sub, ProjectRole.MEMBER);
     if (!attachment.deletedAt) return this.serializeAttachment(attachment);
     return this.prisma.$transaction(async (tx) => {
       const restored = await tx.taskAttachment.update({
         where: { id },
         data: { deletedAt: null, uploadToken: randomBytes(16).toString('hex') },
       });
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor: req.user.sub,
         entityType: 'Task',

--- a/apps/core-api/src/tasks/task-comments.service.ts
+++ b/apps/core-api/src/tasks/task-comments.service.ts
@@ -6,7 +6,8 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { ProjectRole } from '@prisma/client';
-import { DomainService } from '../common/domain.service';
+import { AuditOutboxService } from '../common/audit-outbox.service';
+import { AuthorizationService } from '../common/authorization.service';
 import type { AppRequest } from '../common/types';
 import { NotificationsService } from '../notifications/notifications.service';
 import { PrismaService } from '../prisma/prisma.service';
@@ -18,14 +19,15 @@ const MAX_COMMENT_BODY_LENGTH = 5000;
 export class TaskCommentsService {
   constructor(
     @Inject(PrismaService) private readonly prisma: PrismaService,
-    @Inject(DomainService) private readonly domain: DomainService,
+    @Inject(AuditOutboxService) private readonly auditOutbox: AuditOutboxService,
+    @Inject(AuthorizationService) private readonly authorization: AuthorizationService,
     @Inject(NotificationsService) private readonly notifications: NotificationsService,
     @Inject(TaskMentionsService) private readonly mentions: TaskMentionsService,
   ) {}
 
   async listMentions(taskId: string, req: AppRequest) {
     const task = await this.prisma.task.findFirstOrThrow({ where: { id: taskId, deletedAt: null } });
-    await this.domain.requireProjectRole(task.projectId, req.user.sub, ProjectRole.VIEWER);
+    await this.authorization.requireProjectRole(task.projectId, req.user.sub, ProjectRole.VIEWER);
 
     const mentions = await this.prisma.taskMention.findMany({
       where: { taskId },
@@ -52,7 +54,7 @@ export class TaskCommentsService {
 
   async listComments(taskId: string, req: AppRequest) {
     const task = await this.prisma.task.findFirstOrThrow({ where: { id: taskId, deletedAt: null } });
-    await this.domain.requireProjectRole(task.projectId, req.user.sub, ProjectRole.VIEWER);
+    await this.authorization.requireProjectRole(task.projectId, req.user.sub, ProjectRole.VIEWER);
     const comments = await this.prisma.taskComment.findMany({
       where: { taskId, deletedAt: null },
       orderBy: { createdAt: 'asc' },
@@ -84,7 +86,7 @@ export class TaskCommentsService {
 
   async createComment(taskId: string, commentBody: string, req: AppRequest) {
     const task = await this.prisma.task.findFirstOrThrow({ where: { id: taskId, deletedAt: null } });
-    await this.domain.requireProjectRole(task.projectId, req.user.sub, ProjectRole.MEMBER);
+    await this.authorization.requireProjectRole(task.projectId, req.user.sub, ProjectRole.MEMBER);
     const trimmedBody = this.normalizeCommentBody(commentBody);
 
     return this.prisma.$transaction(async (tx) => {
@@ -95,7 +97,7 @@ export class TaskCommentsService {
           body: trimmedBody,
         },
       });
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor: req.user.sub,
         entityType: 'Task',
@@ -133,7 +135,7 @@ export class TaskCommentsService {
 
   async patchComment(id: string, commentBody: string, req: AppRequest) {
     const comment = await this.prisma.taskComment.findUniqueOrThrow({ where: { id }, include: { task: true } });
-    await this.domain.requireProjectRole(comment.task.projectId, req.user.sub, ProjectRole.MEMBER);
+    await this.authorization.requireProjectRole(comment.task.projectId, req.user.sub, ProjectRole.MEMBER);
     if (comment.deletedAt) throw new NotFoundException('Comment not found');
     if (comment.authorUserId !== req.user.sub) throw new ForbiddenException('Can only edit your own comment');
     const trimmedBody = this.normalizeCommentBody(commentBody);
@@ -143,7 +145,7 @@ export class TaskCommentsService {
         where: { id },
         data: { body: trimmedBody },
       });
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor: req.user.sub,
         entityType: 'Task',
@@ -171,7 +173,7 @@ export class TaskCommentsService {
 
   async deleteComment(id: string, req: AppRequest) {
     const comment = await this.prisma.taskComment.findUniqueOrThrow({ where: { id }, include: { task: true } });
-    await this.domain.requireProjectRole(comment.task.projectId, req.user.sub, ProjectRole.MEMBER);
+    await this.authorization.requireProjectRole(comment.task.projectId, req.user.sub, ProjectRole.MEMBER);
     if (comment.deletedAt) return comment;
     if (comment.authorUserId !== req.user.sub) throw new ForbiddenException('Can only delete your own comment');
 
@@ -188,7 +190,7 @@ export class TaskCommentsService {
           where: { id: { in: existingMentions.map((item) => item.id) } },
         });
         for (const mention of existingMentions) {
-          await this.domain.appendAuditOutbox({
+          await this.auditOutbox.appendAuditOutbox({
             tx,
             actor: req.user.sub,
             entityType: 'Task',
@@ -206,7 +208,7 @@ export class TaskCommentsService {
           });
         }
       }
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor: req.user.sub,
         entityType: 'Task',

--- a/apps/core-api/src/tasks/task-dependencies.controller.ts
+++ b/apps/core-api/src/tasks/task-dependencies.controller.ts
@@ -2,10 +2,10 @@ import { BadRequestException, Body, Controller, Get, Inject, Param, Post, Delete
 import { IsArray, IsEnum, IsISO8601, IsOptional, IsString, IsUUID } from 'class-validator';
 import { DependencyType, Priority, ProjectRole, TaskStatus } from '@prisma/client';
 import { AuthGuard } from '../auth/auth.guard';
+import { AuthorizationService } from '../common/authorization.service';
 import { CurrentRequest } from '../common/current-request';
 import type { AppRequest } from '../common/types';
 import { assertValidDateRange, toDateOnlyDate } from '../common/date-validation';
-import { DomainService } from '../common/domain.service';
 import { PrismaService } from '../prisma/prisma.service';
 import { SubtaskService } from './subtask.service';
 
@@ -56,14 +56,14 @@ class AddDependencyDto {
 export class TaskDependenciesController {
   constructor(
     @Inject(PrismaService) private readonly prisma: PrismaService,
-    @Inject(DomainService) private readonly domain: DomainService,
+    @Inject(AuthorizationService) private readonly authorization: AuthorizationService,
     @Inject(SubtaskService) private readonly subtaskService: SubtaskService,
   ) {}
 
   @Post('tasks/:id/subtasks')
   async createSubtask(@Param('id') parentId: string, @Body() body: CreateSubtaskDto, @CurrentRequest() req: AppRequest) {
     const parentTask = await this.prisma.task.findFirstOrThrow({ where: { id: parentId, deletedAt: null } });
-    await this.domain.requireProjectRole(parentTask.projectId, req.user.sub, ProjectRole.MEMBER);
+    await this.authorization.requireProjectRole(parentTask.projectId, req.user.sub, ProjectRole.MEMBER);
     if (parentTask.parentId) {
       throw new BadRequestException('Nested subtasks are not supported');
     }
@@ -91,35 +91,35 @@ export class TaskDependenciesController {
   @Get('tasks/:id/subtasks')
   async getSubtasks(@Param('id') taskId: string, @CurrentRequest() req: AppRequest) {
     const task = await this.prisma.task.findFirstOrThrow({ where: { id: taskId, deletedAt: null } });
-    await this.domain.requireProjectRole(task.projectId, req.user.sub, ProjectRole.VIEWER);
+    await this.authorization.requireProjectRole(task.projectId, req.user.sub, ProjectRole.VIEWER);
     return this.subtaskService.getSubtasks(taskId);
   }
 
   @Get('tasks/:id/subtasks/tree')
   async getSubtaskTree(@Param('id') taskId: string, @CurrentRequest() req: AppRequest) {
     const task = await this.prisma.task.findFirstOrThrow({ where: { id: taskId, deletedAt: null } });
-    await this.domain.requireProjectRole(task.projectId, req.user.sub, ProjectRole.VIEWER);
+    await this.authorization.requireProjectRole(task.projectId, req.user.sub, ProjectRole.VIEWER);
     return this.subtaskService.getSubtaskTree(taskId);
   }
 
   @Get('tasks/:id/breadcrumbs')
   async getBreadcrumbs(@Param('id') taskId: string, @CurrentRequest() req: AppRequest) {
     const task = await this.prisma.task.findFirstOrThrow({ where: { id: taskId, deletedAt: null } });
-    await this.domain.requireProjectRole(task.projectId, req.user.sub, ProjectRole.VIEWER);
+    await this.authorization.requireProjectRole(task.projectId, req.user.sub, ProjectRole.VIEWER);
     return this.subtaskService.getBreadcrumbPath(taskId);
   }
 
   @Post('tasks/:id/dependencies')
   async addDependency(@Param('id') taskId: string, @Body() body: AddDependencyDto, @CurrentRequest() req: AppRequest) {
     const task = await this.prisma.task.findFirstOrThrow({ where: { id: taskId, deletedAt: null } });
-    await this.domain.requireProjectRole(task.projectId, req.user.sub, ProjectRole.MEMBER);
+    await this.authorization.requireProjectRole(task.projectId, req.user.sub, ProjectRole.MEMBER);
     return this.subtaskService.addDependency(taskId, body.dependsOnId, body.type, req.user.sub, req.correlationId);
   }
 
   @Delete('tasks/:id/dependencies/:dependsOnId')
   async removeDependency(@Param('id') taskId: string, @Param('dependsOnId') dependsOnId: string, @CurrentRequest() req: AppRequest) {
     const task = await this.prisma.task.findFirstOrThrow({ where: { id: taskId, deletedAt: null } });
-    await this.domain.requireProjectRole(task.projectId, req.user.sub, ProjectRole.MEMBER);
+    await this.authorization.requireProjectRole(task.projectId, req.user.sub, ProjectRole.MEMBER);
     await this.subtaskService.removeDependencyWithAudit(taskId, dependsOnId, req.user.sub, req.correlationId);
     return { success: true };
   }
@@ -127,28 +127,28 @@ export class TaskDependenciesController {
   @Get('tasks/:id/dependencies')
   async getDependencies(@Param('id') taskId: string, @CurrentRequest() req: AppRequest) {
     const task = await this.prisma.task.findFirstOrThrow({ where: { id: taskId, deletedAt: null } });
-    await this.domain.requireProjectRole(task.projectId, req.user.sub, ProjectRole.VIEWER);
+    await this.authorization.requireProjectRole(task.projectId, req.user.sub, ProjectRole.VIEWER);
     return this.subtaskService.getDependencies(taskId);
   }
 
   @Get('tasks/:id/dependents')
   async getDependents(@Param('id') taskId: string, @CurrentRequest() req: AppRequest) {
     const task = await this.prisma.task.findFirstOrThrow({ where: { id: taskId, deletedAt: null } });
-    await this.domain.requireProjectRole(task.projectId, req.user.sub, ProjectRole.VIEWER);
+    await this.authorization.requireProjectRole(task.projectId, req.user.sub, ProjectRole.VIEWER);
     return this.subtaskService.getDependents(taskId);
   }
 
   @Get('tasks/:id/blocked')
   async isBlocked(@Param('id') taskId: string, @CurrentRequest() req: AppRequest) {
     const task = await this.prisma.task.findFirstOrThrow({ where: { id: taskId, deletedAt: null } });
-    await this.domain.requireProjectRole(task.projectId, req.user.sub, ProjectRole.VIEWER);
+    await this.authorization.requireProjectRole(task.projectId, req.user.sub, ProjectRole.VIEWER);
     const blocked = await this.subtaskService.isBlocked(taskId);
     return { blocked };
   }
 
   @Get('projects/:id/dependency-graph')
   async getDependencyGraph(@Param('id') projectId: string, @CurrentRequest() req: AppRequest) {
-    await this.domain.requireProjectRole(projectId, req.user.sub, ProjectRole.VIEWER);
+    await this.authorization.requireProjectRole(projectId, req.user.sub, ProjectRole.VIEWER);
     return this.subtaskService.getDependencyGraph(projectId);
   }
 }

--- a/apps/core-api/src/tasks/task-mentions.service.ts
+++ b/apps/core-api/src/tasks/task-mentions.service.ts
@@ -1,13 +1,13 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { Prisma } from '@prisma/client';
-import { DomainService } from '../common/domain.service';
+import { AuditOutboxService } from '../common/audit-outbox.service';
 import type { AppRequest } from '../common/types';
 import { NotificationsService } from '../notifications/notifications.service';
 
 @Injectable()
 export class TaskMentionsService {
   constructor(
-    @Inject(DomainService) private readonly domain: DomainService,
+    @Inject(AuditOutboxService) private readonly auditOutbox: AuditOutboxService,
     @Inject(NotificationsService) private readonly notifications: NotificationsService,
   ) {}
 
@@ -87,7 +87,7 @@ export class TaskMentionsService {
       const created = await tx.taskMention.create({
         data: { taskId: input.taskId, mentionedUserId: userId, sourceType: input.sourceType, sourceId },
       });
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor: req.user.sub,
         entityType: 'Task',
@@ -117,7 +117,7 @@ export class TaskMentionsService {
 
     for (const mention of toDelete) {
       await tx.taskMention.delete({ where: { id: mention.id } });
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor: req.user.sub,
         entityType: 'Task',

--- a/apps/core-api/src/tasks/task-reminders.service.ts
+++ b/apps/core-api/src/tasks/task-reminders.service.ts
@@ -1,6 +1,7 @@
 import { ConflictException, Inject, Injectable } from '@nestjs/common';
 import { ProjectRole } from '@prisma/client';
-import { DomainService } from '../common/domain.service';
+import { AuditOutboxService } from '../common/audit-outbox.service';
+import { AuthorizationService } from '../common/authorization.service';
 import type { AppRequest } from '../common/types';
 import { PrismaService } from '../prisma/prisma.service';
 
@@ -8,12 +9,13 @@ import { PrismaService } from '../prisma/prisma.service';
 export class TaskRemindersService {
   constructor(
     @Inject(PrismaService) private readonly prisma: PrismaService,
-    @Inject(DomainService) private readonly domain: DomainService,
+    @Inject(AuditOutboxService) private readonly auditOutbox: AuditOutboxService,
+    @Inject(AuthorizationService) private readonly authorization: AuthorizationService,
   ) {}
 
   async getMyReminder(taskId: string, req: AppRequest) {
     const task = await this.prisma.task.findFirstOrThrow({ where: { id: taskId, deletedAt: null } });
-    await this.domain.requireProjectRole(task.projectId, req.user.sub, ProjectRole.VIEWER);
+    await this.authorization.requireProjectRole(task.projectId, req.user.sub, ProjectRole.VIEWER);
     const reminder = await this.prisma.taskReminder.findFirst({
       where: { taskId, userId: req.user.sub, deletedAt: null },
       orderBy: { createdAt: 'desc' },
@@ -23,7 +25,7 @@ export class TaskRemindersService {
 
   async upsertMyReminder(taskId: string, remindAtRaw: string, req: AppRequest) {
     const task = await this.prisma.task.findFirstOrThrow({ where: { id: taskId, deletedAt: null } });
-    await this.domain.requireProjectRole(task.projectId, req.user.sub, ProjectRole.MEMBER);
+    await this.authorization.requireProjectRole(task.projectId, req.user.sub, ProjectRole.MEMBER);
     const remindAt = new Date(remindAtRaw);
     if (Number.isNaN(+remindAt)) throw new ConflictException('Invalid remindAt');
 
@@ -41,7 +43,7 @@ export class TaskRemindersService {
             data: { taskId, userId: req.user.sub, remindAt },
           });
 
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor: req.user.sub,
         entityType: 'Task',
@@ -59,7 +61,7 @@ export class TaskRemindersService {
 
   async clearMyReminder(taskId: string, req: AppRequest) {
     const task = await this.prisma.task.findFirstOrThrow({ where: { id: taskId, deletedAt: null } });
-    await this.domain.requireProjectRole(task.projectId, req.user.sub, ProjectRole.MEMBER);
+    await this.authorization.requireProjectRole(task.projectId, req.user.sub, ProjectRole.MEMBER);
     const current = await this.prisma.taskReminder.findFirst({
       where: { taskId, userId: req.user.sub, deletedAt: null },
       orderBy: { createdAt: 'desc' },
@@ -71,7 +73,7 @@ export class TaskRemindersService {
         where: { id: current.id },
         data: { deletedAt: new Date() },
       });
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor: req.user.sub,
         entityType: 'Task',

--- a/apps/core-api/src/tasks/task-retention.service.ts
+++ b/apps/core-api/src/tasks/task-retention.service.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable, Logger, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
 import { randomUUID } from 'node:crypto';
-import { DomainService } from '../common/domain.service';
+import { AuditOutboxService } from '../common/audit-outbox.service';
 import { PrismaService } from '../prisma/prisma.service';
 
 @Injectable()
@@ -11,7 +11,7 @@ export class TaskRetentionService implements OnModuleInit, OnModuleDestroy {
 
   constructor(
     @Inject(PrismaService) private readonly prisma: PrismaService,
-    @Inject(DomainService) private readonly domain: DomainService,
+    @Inject(AuditOutboxService) private readonly auditOutbox: AuditOutboxService,
   ) {}
 
   onModuleInit() {
@@ -48,7 +48,7 @@ export class TaskRetentionService implements OnModuleInit, OnModuleDestroy {
 
     const deletedCount = await this.prisma.$transaction(async (tx) => {
       for (const task of candidates) {
-        await this.domain.appendAuditOutbox({
+        await this.auditOutbox.appendAuditOutbox({
           tx,
           actor: 'retention-worker',
           entityType: 'Task',

--- a/apps/core-api/src/tasks/tasks.controller.ts
+++ b/apps/core-api/src/tasks/tasks.controller.ts
@@ -31,6 +31,8 @@ import {
   ValidateNested,
 } from 'class-validator';
 import { AuthGuard } from '../auth/auth.guard';
+import { AuditOutboxService } from '../common/audit-outbox.service';
+import { AuthorizationService } from '../common/authorization.service';
 import { PrismaService } from '../prisma/prisma.service';
 import { DomainService } from '../common/domain.service';
 import { CurrentRequest } from '../common/current-request';
@@ -492,6 +494,8 @@ function createEmptyTimelineManualLayoutState(): TimelineManualLayoutState {
 @UseGuards(AuthGuard)
 export class TasksController {
   constructor(
+    @Inject(AuditOutboxService) private readonly auditOutbox: AuditOutboxService,
+    @Inject(AuthorizationService) private readonly authorization: AuthorizationService,
     @Inject(PrismaService) private readonly prisma: PrismaService,
     @Inject(DomainService) private readonly domain: DomainService,
     @Inject(SearchService) private readonly searchService: SearchService,
@@ -501,7 +505,7 @@ export class TasksController {
 
   @Get('projects/:id/tasks')
   async list(@Param('id') projectId: string, @Query() query: TaskQuery, @CurrentRequest() req: AppRequest) {
-    await this.domain.requireProjectRole(projectId, req.user.sub, ProjectRole.VIEWER);
+    await this.authorization.requireProjectRole(projectId, req.user.sub, ProjectRole.VIEWER);
 
     const customFieldFilters = parseTaskCustomFieldFilters(query.customFieldFilters ?? query.cf);
     const customFieldSort = parseTaskCustomFieldSort(query.customFieldSortFieldId, query.customFieldSortOrder);
@@ -581,7 +585,7 @@ export class TasksController {
 
   @Get('projects/:id/timeline/preferences')
   async getTimelinePreferences(@Param('id') projectId: string, @CurrentRequest() req: AppRequest) {
-    await this.domain.requireProjectRole(projectId, req.user.sub, ProjectRole.VIEWER);
+    await this.authorization.requireProjectRole(projectId, req.user.sub, ProjectRole.VIEWER);
     const preferences = await this.prisma.projectTimelinePreference.findUnique({
       where: { projectId_userId: { projectId, userId: req.user.sub } },
     });
@@ -603,7 +607,7 @@ export class TasksController {
     @Body() body: PutTimelineLaneOrderDto,
     @CurrentRequest() req: AppRequest,
   ) {
-    await this.domain.requireProjectRole(projectId, req.user.sub, ProjectRole.MEMBER);
+    await this.authorization.requireProjectRole(projectId, req.user.sub, ProjectRole.MEMBER);
     const groupBy = this.parseTimelineGroupBy(rawGroupBy);
 
     return this.prisma.$transaction(async (tx) => {
@@ -626,7 +630,7 @@ export class TasksController {
             : { laneOrderByAssignee: normalizedLaneOrder },
       });
 
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor: req.user.sub,
         entityType: 'ProjectTimelinePreference',
@@ -663,7 +667,7 @@ export class TasksController {
     @Body() body: PutTimelineManualLayoutDto,
     @CurrentRequest() req: AppRequest,
   ) {
-    await this.domain.requireProjectRole(projectId, req.user.sub, ProjectRole.MEMBER);
+    await this.authorization.requireProjectRole(projectId, req.user.sub, ProjectRole.MEMBER);
     const groupBy = this.parseTimelineSwimlane(rawGroupBy);
 
     return this.prisma.$transaction(async (tx) => {
@@ -699,7 +703,7 @@ export class TasksController {
         },
       });
 
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor: req.user.sub,
         entityType: 'ProjectTimelinePreference',
@@ -736,7 +740,7 @@ export class TasksController {
     @Body() body: PutTimelineViewStateDto,
     @CurrentRequest() req: AppRequest,
   ) {
-    await this.domain.requireProjectRole(projectId, req.user.sub, ProjectRole.MEMBER);
+    await this.authorization.requireProjectRole(projectId, req.user.sub, ProjectRole.MEMBER);
     const mode = this.parseTimelineViewMode(rawMode);
     const normalizedViewState = this.normalizeTimelineViewState(mode, body);
 
@@ -758,7 +762,7 @@ export class TasksController {
             : { ganttViewState: normalizedViewState },
       });
 
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor: req.user.sub,
         entityType: 'ProjectTimelinePreference',
@@ -791,14 +795,14 @@ export class TasksController {
   @Get('tasks/:id')
   async getOne(@Param('id') id: string, @CurrentRequest() req: AppRequest) {
     const task = await this.prisma.task.findFirstOrThrow({ where: { id, deletedAt: null } });
-    await this.domain.requireProjectRole(task.projectId, req.user.sub, ProjectRole.VIEWER);
+    await this.authorization.requireProjectRole(task.projectId, req.user.sub, ProjectRole.VIEWER);
     return this.hydrateTaskWithFollowerState(task, req.user.sub);
   }
 
   @Get('tasks/:id/followers')
   async followers(@Param('id') id: string, @CurrentRequest() req: AppRequest) {
     const task = await this.prisma.task.findFirstOrThrow({ where: { id, deletedAt: null } });
-    await this.domain.requireProjectRole(task.projectId, req.user.sub, ProjectRole.VIEWER);
+    await this.authorization.requireProjectRole(task.projectId, req.user.sub, ProjectRole.VIEWER);
 
     const followers = await this.prisma.taskFollower.findMany({
       where: { taskId: id },
@@ -827,14 +831,14 @@ export class TasksController {
   @Post('tasks/:id/followers')
   async follow(@Param('id') id: string, @CurrentRequest() req: AppRequest) {
     const task = await this.prisma.task.findFirstOrThrow({ where: { id, deletedAt: null } });
-    await this.domain.requireProjectRole(task.projectId, req.user.sub, ProjectRole.VIEWER);
+    await this.authorization.requireProjectRole(task.projectId, req.user.sub, ProjectRole.VIEWER);
 
     try {
       return await this.prisma.$transaction(async (tx) => {
         const follower = await tx.taskFollower.create({
           data: { taskId: id, userId: req.user.sub },
         });
-        await this.domain.appendAuditOutbox({
+        await this.auditOutbox.appendAuditOutbox({
           tx,
           actor: req.user.sub,
           entityType: 'TaskFollower',
@@ -869,7 +873,7 @@ export class TasksController {
   @Delete('tasks/:id/followers/me')
   async unfollow(@Param('id') id: string, @CurrentRequest() req: AppRequest) {
     const task = await this.prisma.task.findFirstOrThrow({ where: { id, deletedAt: null } });
-    await this.domain.requireProjectRole(task.projectId, req.user.sub, ProjectRole.VIEWER);
+    await this.authorization.requireProjectRole(task.projectId, req.user.sub, ProjectRole.VIEWER);
 
     return this.prisma.$transaction(async (tx) => {
       const existing = await tx.taskFollower.findUnique({
@@ -877,7 +881,7 @@ export class TasksController {
       });
       if (existing) {
         await tx.taskFollower.delete({ where: { id: existing.id } });
-        await this.domain.appendAuditOutbox({
+        await this.auditOutbox.appendAuditOutbox({
           tx,
           actor: req.user.sub,
           entityType: 'TaskFollower',
@@ -896,7 +900,7 @@ export class TasksController {
 
   @Post('projects/:id/tasks')
   async create(@Param('id') projectId: string, @Body() body: CreateTaskDto, @CurrentRequest() req: AppRequest) {
-    await this.domain.requireProjectRole(projectId, req.user.sub, ProjectRole.MEMBER);
+    await this.authorization.requireProjectRole(projectId, req.user.sub, ProjectRole.MEMBER);
 
     assertValidDateRange(body.startAt, body.dueAt);
     assertValidDateRange(body.baselineStartAt, body.baselineDueAt, {
@@ -955,7 +959,7 @@ export class TasksController {
           position,
         },
       });
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor: req.user.sub,
         entityType: 'Task',
@@ -977,7 +981,7 @@ export class TasksController {
   @Patch('tasks/:id')
   async patch(@Param('id') id: string, @Body() body: PatchTaskDto, @CurrentRequest() req: AppRequest) {
     const task = await this.prisma.task.findFirstOrThrow({ where: { id, deletedAt: null } });
-    await this.domain.requireProjectRole(task.projectId, req.user.sub, ProjectRole.MEMBER);
+    await this.authorization.requireProjectRole(task.projectId, req.user.sub, ProjectRole.MEMBER);
     if (body.version && body.version !== task.version) throw new ConflictException('Version conflict');
 
     const effectiveStartAt = body.startAt === undefined ? normalizeDateOnlyField(task.startAt) : body.startAt;
@@ -1036,7 +1040,7 @@ export class TasksController {
           version: { increment: 1 },
         },
       });
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor: req.user.sub,
         entityType: 'Task',
@@ -1107,7 +1111,7 @@ export class TasksController {
   @Patch('tasks/:id/reschedule')
   async reschedule(@Param('id') id: string, @Body() body: RescheduleTaskDto, @CurrentRequest() req: AppRequest) {
     const task = await this.prisma.task.findFirstOrThrow({ where: { id, deletedAt: null } });
-    await this.domain.requireProjectRole(task.projectId, req.user.sub, ProjectRole.MEMBER);
+    await this.authorization.requireProjectRole(task.projectId, req.user.sub, ProjectRole.MEMBER);
     if (body.startAt === undefined && body.dueAt === undefined) {
       throw new BadRequestException('Either startAt or dueAt must be provided');
     }
@@ -1150,7 +1154,7 @@ export class TasksController {
 
       const updated = await tx.task.findFirstOrThrow({ where: { id, deletedAt: null } });
       const subtaskMovePolicy = await this.buildTimelineSubtaskMovePolicy(tx, id);
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor: req.user.sub,
         entityType: 'Task',
@@ -1192,7 +1196,7 @@ export class TasksController {
   @Patch('tasks/:id/timeline-move')
   async moveInTimeline(@Param('id') id: string, @Body() body: TimelineMoveTaskDto, @CurrentRequest() req: AppRequest) {
     const task = await this.prisma.task.findFirstOrThrow({ where: { id, deletedAt: null } });
-    await this.domain.requireProjectRole(task.projectId, req.user.sub, ProjectRole.MEMBER);
+    await this.authorization.requireProjectRole(task.projectId, req.user.sub, ProjectRole.MEMBER);
 
     const rawDropAt = body.dropAt;
     const hasSchedulePatch = body.startAt !== undefined || body.dueAt !== undefined;
@@ -1230,7 +1234,7 @@ export class TasksController {
       throw new BadRequestException('assigneeUserId must be a non-empty string or null');
     }
     if (hasAssigneePatch && typeof body.assigneeUserId === 'string') {
-      await this.domain.requireProjectRole(task.projectId, body.assigneeUserId, ProjectRole.VIEWER);
+      await this.authorization.requireProjectRole(task.projectId, body.assigneeUserId, ProjectRole.VIEWER);
     }
     if (hasSectionPatch) {
       const section = await this.prisma.section.findFirst({
@@ -1458,7 +1462,7 @@ export class TasksController {
         });
         serializedCurrentCustomFieldValues = currentValues.map((value) => this.serializeTaskCustomFieldValue(value));
       }
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor: req.user.sub,
         entityType: 'Task',
@@ -1519,7 +1523,7 @@ export class TasksController {
     @CurrentRequest() req: AppRequest,
   ) {
     const task = await this.prisma.task.findFirstOrThrow({ where: { id, deletedAt: null } });
-    await this.domain.requireProjectRole(task.projectId, req.user.sub, ProjectRole.MEMBER);
+    await this.authorization.requireProjectRole(task.projectId, req.user.sub, ProjectRole.MEMBER);
 
     if (body.version !== task.version) {
       throw new ConflictException({
@@ -1630,7 +1634,7 @@ export class TasksController {
       });
       const serializedCurrent = currentValues.map((value) => this.serializeTaskCustomFieldValue(value));
 
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor: req.user.sub,
         entityType: 'Task',
@@ -1677,7 +1681,7 @@ export class TasksController {
   @Post('tasks/:id/complete')
   async complete(@Param('id') id: string, @Body() body: CompleteTaskDto, @CurrentRequest() req: AppRequest) {
     const task = await this.prisma.task.findFirstOrThrow({ where: { id, deletedAt: null } });
-    await this.domain.requireProjectRole(task.projectId, req.user.sub, ProjectRole.MEMBER);
+    await this.authorization.requireProjectRole(task.projectId, req.user.sub, ProjectRole.MEMBER);
 
     return this.prisma.$transaction(async (tx) => {
       const unitOfWork = createTaskLifecycleUnitOfWorkFromTx(tx);
@@ -1707,7 +1711,7 @@ export class TasksController {
       });
       const updated = await tx.task.findUniqueOrThrow({ where: { id } });
 
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor: req.user.sub,
         entityType: 'Task',
@@ -1736,7 +1740,7 @@ export class TasksController {
   @Delete('tasks/:id')
   async remove(@Param('id') id: string, @CurrentRequest() req: AppRequest) {
     const task = await this.prisma.task.findFirstOrThrow({ where: { id, deletedAt: null } });
-    await this.domain.requireProjectRole(task.projectId, req.user.sub, ProjectRole.MEMBER);
+    await this.authorization.requireProjectRole(task.projectId, req.user.sub, ProjectRole.MEMBER);
     if (task.deletedAt) return { success: true };
 
     return this.prisma.$transaction(async (tx) => {
@@ -1749,7 +1753,7 @@ export class TasksController {
         where: { id: { in: subtreeIds } },
         data: { deletedAt: now, deletedByUserId: req.user.sub, updatedAt: now, version: { increment: 1 } },
       });
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor: req.user.sub,
         entityType: 'Task',
@@ -1771,7 +1775,7 @@ export class TasksController {
   @Post('tasks/:id/restore')
   async restore(@Param('id') id: string, @CurrentRequest() req: AppRequest) {
     const task = await this.prisma.task.findUniqueOrThrow({ where: { id } });
-    await this.domain.requireProjectRole(task.projectId, req.user.sub, ProjectRole.MEMBER);
+    await this.authorization.requireProjectRole(task.projectId, req.user.sub, ProjectRole.MEMBER);
     if (!task.deletedAt) return task;
 
     return this.prisma.$transaction(async (tx) => {
@@ -1781,7 +1785,7 @@ export class TasksController {
         data: { deletedAt: null, deletedByUserId: null, version: { increment: 1 } },
       });
       const updatedTask = await tx.task.findUniqueOrThrow({ where: { id } });
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor: req.user.sub,
         entityType: 'Task',
@@ -1808,7 +1812,7 @@ export class TasksController {
   ) {
     this.validateDescriptionDoc(body.descriptionDoc);
     const task = await this.prisma.task.findUniqueOrThrow({ where: { id } });
-    await this.domain.requireProjectRole(task.projectId, req.user.sub, ProjectRole.MEMBER);
+    await this.authorization.requireProjectRole(task.projectId, req.user.sub, ProjectRole.MEMBER);
 
     if (task.descriptionVersion !== body.expectedVersion) {
       throw new ConflictException({
@@ -1834,7 +1838,7 @@ export class TasksController {
           version: { increment: 1 },
         },
       });
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor: req.user.sub,
         entityType: 'Task',
@@ -1875,7 +1879,7 @@ export class TasksController {
     const firstTask = tasks[0];
     if (!firstTask) return { count: 0 };
     const projectId = firstTask.projectId;
-    await this.domain.requireProjectRole(projectId, req.user.sub, ProjectRole.MEMBER);
+    await this.authorization.requireProjectRole(projectId, req.user.sub, ProjectRole.MEMBER);
 
     return this.prisma.$transaction(async (tx) => {
       const updated = [] as unknown[];
@@ -1910,7 +1914,7 @@ export class TasksController {
           },
         });
         updated.push(next);
-        await this.domain.appendAuditOutbox({
+        await this.auditOutbox.appendAuditOutbox({
           tx,
           actor: req.user.sub,
           entityType: 'Task',
@@ -1935,7 +1939,7 @@ export class TasksController {
     @CurrentRequest() req: AppRequest,
   ) {
     const task = await this.prisma.task.findFirstOrThrow({ where: { id: body.taskId, deletedAt: null } });
-    await this.domain.requireProjectRole(task.projectId, req.user.sub, ProjectRole.MEMBER);
+    await this.authorization.requireProjectRole(task.projectId, req.user.sub, ProjectRole.MEMBER);
     if (body.expectedVersion && body.expectedVersion !== task.version) {
       const sectionTasks = await this.prisma.task.findMany({
         where: { projectId: task.projectId, sectionId: targetSectionId, deletedAt: null },
@@ -1993,7 +1997,7 @@ export class TasksController {
         },
       });
 
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor: req.user.sub,
         entityType: 'Task',
@@ -2460,7 +2464,7 @@ export class TasksController {
       if (patch) {
         const before = { ...task };
         const updated = await tx.task.update({ where: { id: taskId }, data: patch });
-        await this.domain.appendAuditOutbox({
+        await this.auditOutbox.appendAuditOutbox({
           tx,
           actor: 'rule-engine',
           entityType: 'Task',

--- a/apps/core-api/src/webhooks/webhooks.controller.ts
+++ b/apps/core-api/src/webhooks/webhooks.controller.ts
@@ -1,8 +1,9 @@
 import { BadRequestException, Body, ConflictException, Controller, Get, Inject, Param, Post, Query, UseGuards } from '@nestjs/common';
 import { IsString, IsUrl, IsUUID } from 'class-validator';
 import { AuthGuard } from '../auth/auth.guard';
+import { AuditOutboxService } from '../common/audit-outbox.service';
+import { AuthorizationService } from '../common/authorization.service';
 import { PrismaService } from '../prisma/prisma.service';
-import { DomainService } from '../common/domain.service';
 import { CurrentRequest } from '../common/current-request';
 import type { AppRequest } from '../common/types';
 import { ProjectRole } from '@prisma/client';
@@ -27,7 +28,8 @@ class RetryDeadLetterDto {
 export class WebhooksController {
   constructor(
     @Inject(PrismaService) private readonly prisma: PrismaService,
-    @Inject(DomainService) private readonly domain: DomainService,
+    @Inject(AuditOutboxService) private readonly auditOutbox: AuditOutboxService,
+    @Inject(AuthorizationService) private readonly authorization: AuthorizationService,
   ) {}
 
   @Post()
@@ -35,7 +37,7 @@ export class WebhooksController {
   async create(@Body() body: CreateWebhookDto, @CurrentRequest() req: AppRequest) {
     return this.prisma.$transaction(async (tx) => {
       const webhook = await tx.webhook.create({ data: body });
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor: req.user.sub,
         entityType: 'Webhook',
@@ -53,7 +55,7 @@ export class WebhooksController {
   @Get('dlq')
   async listDeadLetterEvents(@Query('projectId') projectId: string | undefined, @CurrentRequest() req: AppRequest) {
     if (!projectId) throw new BadRequestException('projectId is required');
-    await this.domain.requireProjectRole(projectId, req.user.sub, ProjectRole.ADMIN);
+    await this.authorization.requireProjectRole(projectId, req.user.sub, ProjectRole.ADMIN);
 
     const [projectTaskRows, projectSectionRows, deadLetterEvents] = await Promise.all([
       this.prisma.task.findMany({ where: { projectId }, select: { id: true } }),
@@ -113,7 +115,7 @@ export class WebhooksController {
       const updated = await tx.outboxEvent.findUniqueOrThrow({
         where: { id: eventId },
       });
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor: req.user.sub,
         entityType: 'OutboxEvent',

--- a/apps/core-api/src/workload/workload.module.ts
+++ b/apps/core-api/src/workload/workload.module.ts
@@ -1,14 +1,13 @@
 import { Module } from '@nestjs/common';
 import { AuthModule } from '../auth/auth.module';
 import { CapacityModule } from '../capacity/capacity.module';
-import { DomainService } from '../common/domain.service';
-import { PrismaService } from '../prisma/prisma.service';
+import { CommonServicesModule } from '../common/common-services.module';
 import { WorkloadService } from './workload.service';
 import { WorkloadController } from './workload.controller';
 
 @Module({
-  imports: [AuthModule, CapacityModule],
+  imports: [AuthModule, CapacityModule, CommonServicesModule],
   controllers: [WorkloadController],
-  providers: [PrismaService, DomainService, WorkloadService],
+  providers: [WorkloadService],
 })
 export class WorkloadModule {}

--- a/apps/core-api/src/workload/workload.service.ts
+++ b/apps/core-api/src/workload/workload.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, NotFoundException, Inject } from '@nestjs/common';
+import { AuthorizationService } from '../common/authorization.service';
 import { PrismaService } from '../prisma/prisma.service';
-import { DomainService } from '../common/domain.service';
 import { WorkspaceRole } from '@prisma/client';
 import { CapacityService } from '../capacity/capacity.service';
 
@@ -58,7 +58,7 @@ export class WorkloadService {
 
   constructor(
     @Inject(PrismaService) private readonly prisma: PrismaService,
-    @Inject(DomainService) private readonly domain: DomainService,
+    @Inject(AuthorizationService) private readonly authorization: AuthorizationService,
     @Inject(CapacityService) private readonly capacityService: CapacityService,
   ) {}
 
@@ -68,9 +68,9 @@ export class WorkloadService {
     filters: WorkloadFilters,
     actorUserId: string,
   ): Promise<UserWorkload> {
-    await this.domain.requireWorkspaceMembership(workspaceId, actorUserId);
+    await this.authorization.requireWorkspaceMembership(workspaceId, actorUserId);
     if (actorUserId !== targetUserId) {
-      await this.domain.requireWorkspaceRole(workspaceId, actorUserId, WorkspaceRole.WS_ADMIN);
+      await this.authorization.requireWorkspaceRole(workspaceId, actorUserId, WorkspaceRole.WS_ADMIN);
     }
 
     const user = await this.prisma.user.findUnique({
@@ -138,7 +138,7 @@ export class WorkloadService {
     filters: WorkloadFilters,
     actorUserId: string,
   ): Promise<UserWorkload[]> {
-    await this.domain.requireWorkspaceMembership(workspaceId, actorUserId);
+    await this.authorization.requireWorkspaceMembership(workspaceId, actorUserId);
 
     const members = await this.prisma.workspaceMembership.findMany({
       where: { workspaceId },
@@ -168,7 +168,7 @@ export class WorkloadService {
     filters: WorkloadFilters,
     actorUserId: string,
   ): Promise<UserWorkload[]> {
-    await this.domain.requireWorkspaceMembership(workspaceId, actorUserId);
+    await this.authorization.requireWorkspaceMembership(workspaceId, actorUserId);
 
     const project = await this.prisma.project.findFirst({
       where: { id: projectId, workspaceId },

--- a/apps/core-api/src/workspaces/workspace-admin.controller.ts
+++ b/apps/core-api/src/workspaces/workspace-admin.controller.ts
@@ -15,7 +15,8 @@ import {
 import { IsEmail, IsEnum, IsOptional, IsString } from 'class-validator';
 import { createHash, randomBytes } from 'node:crypto';
 import { PrismaService } from '../prisma/prisma.service';
-import { DomainService } from '../common/domain.service';
+import { AuditOutboxService } from '../common/audit-outbox.service';
+import { AuthorizationService } from '../common/authorization.service';
 import { AuthGuard } from '../auth/auth.guard';
 import { CurrentRequest } from '../common/current-request';
 import type { AppRequest } from '../common/types';
@@ -55,7 +56,8 @@ class AcceptInvitationDto {
 export class WorkspaceAdminController {
   constructor(
     @Inject(PrismaService) private readonly prisma: PrismaService,
-    @Inject(DomainService) private readonly domain: DomainService,
+    @Inject(AuditOutboxService) private readonly auditOutbox: AuditOutboxService,
+    @Inject(AuthorizationService) private readonly authorization: AuthorizationService,
   ) {}
 
   @Get('workspaces/:id/users')
@@ -126,14 +128,14 @@ export class WorkspaceAdminController {
 
     if (body.status) {
       if (!workspaceId) throw new BadRequestException('workspaceId is required when updating status');
-      await this.domain.requireWorkspaceRole(workspaceId, req.user.sub, WorkspaceRole.WS_ADMIN);
+      await this.authorization.requireWorkspaceRole(workspaceId, req.user.sub, WorkspaceRole.WS_ADMIN);
       const targetMembership = await this.prisma.workspaceMembership.findUnique({
         where: { workspaceId_userId: { workspaceId, userId } },
       });
       if (!targetMembership) throw new BadRequestException('Target user is not in workspace');
     } else if (req.user.sub !== userId) {
       if (!workspaceId) throw new BadRequestException('workspaceId is required when updating another user');
-      await this.domain.requireWorkspaceRole(workspaceId, req.user.sub, WorkspaceRole.WS_ADMIN);
+      await this.authorization.requireWorkspaceRole(workspaceId, req.user.sub, WorkspaceRole.WS_ADMIN);
       const targetMembership = await this.prisma.workspaceMembership.findUnique({
         where: { workspaceId_userId: { workspaceId, userId } },
       });
@@ -150,7 +152,7 @@ export class WorkspaceAdminController {
       });
 
       if (body.status && body.status !== target.status) {
-        await this.domain.appendAuditOutbox({
+        await this.auditOutbox.appendAuditOutbox({
           tx,
           actor: req.user.sub,
           entityType: 'User',
@@ -165,7 +167,7 @@ export class WorkspaceAdminController {
       }
 
       if (body.displayName !== undefined && body.displayName !== target.displayName) {
-        await this.domain.appendAuditOutbox({
+        await this.auditOutbox.appendAuditOutbox({
           tx,
           actor: req.user.sub,
           entityType: 'User',
@@ -206,7 +208,7 @@ export class WorkspaceAdminController {
           createdByUserId: req.user.sub,
         },
       });
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor: req.user.sub,
         entityType: 'Invitation',
@@ -255,14 +257,14 @@ export class WorkspaceAdminController {
   @Delete('invitations/:id')
   async revokeInvitation(@Param('id') invitationId: string, @CurrentRequest() req: AppRequest) {
     const invitation = await this.prisma.invitation.findUniqueOrThrow({ where: { id: invitationId } });
-    await this.domain.requireWorkspaceRole(invitation.workspaceId, req.user.sub, WorkspaceRole.WS_ADMIN);
+    await this.authorization.requireWorkspaceRole(invitation.workspaceId, req.user.sub, WorkspaceRole.WS_ADMIN);
 
     return this.prisma.$transaction(async (tx) => {
       const updated = await tx.invitation.update({
         where: { id: invitationId },
         data: { revokedAt: new Date() },
       });
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor: req.user.sub,
         entityType: 'Invitation',
@@ -281,7 +283,7 @@ export class WorkspaceAdminController {
   @Post('invitations/:id/reissue')
   async reissueInvitation(@Param('id') invitationId: string, @CurrentRequest() req: AppRequest) {
     const invitation = await this.prisma.invitation.findUniqueOrThrow({ where: { id: invitationId } });
-    await this.domain.requireWorkspaceRole(invitation.workspaceId, req.user.sub, WorkspaceRole.WS_ADMIN);
+    await this.authorization.requireWorkspaceRole(invitation.workspaceId, req.user.sub, WorkspaceRole.WS_ADMIN);
     if (invitation.acceptedAt) throw new BadRequestException('Accepted invitation cannot be reissued');
     if (invitation.revokedAt) throw new BadRequestException('Revoked invitation cannot be reissued');
 
@@ -294,7 +296,7 @@ export class WorkspaceAdminController {
         where: { id: invitationId },
         data: { revokedAt: new Date() },
       });
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor: req.user.sub,
         entityType: 'Invitation',
@@ -317,7 +319,7 @@ export class WorkspaceAdminController {
           createdByUserId: req.user.sub,
         },
       });
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor: req.user.sub,
         entityType: 'Invitation',
@@ -394,7 +396,7 @@ export class WorkspaceAdminController {
         data: { acceptedAt: new Date() },
       });
 
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor: req.user.sub,
         entityType: 'Invitation',

--- a/apps/core-api/src/workspaces/workspaces.controller.ts
+++ b/apps/core-api/src/workspaces/workspaces.controller.ts
@@ -3,9 +3,10 @@ import { Type } from 'class-transformer';
 import { IsBoolean, IsInt, IsOptional, Max, Min } from 'class-validator';
 import { AuthGuard } from '../auth/auth.guard';
 import { PrismaService } from '../prisma/prisma.service';
-import { DomainService } from '../common/domain.service';
+import { AuditOutboxService } from '../common/audit-outbox.service';
 import { CurrentRequest } from '../common/current-request';
 import type { AppRequest } from '../common/types';
+import { WorkspaceDefaultsService } from '../common/workspace-defaults.service';
 
 const DEFAULT_REMINDER_PREFERENCES = {
   enabled: true,
@@ -30,19 +31,20 @@ class UpdateReminderPreferencesDto {
 export class WorkspacesController {
   constructor(
     @Inject(PrismaService) private readonly prisma: PrismaService,
-    @Inject(DomainService) private readonly domain: DomainService,
+    @Inject(AuditOutboxService) private readonly auditOutbox: AuditOutboxService,
+    @Inject(WorkspaceDefaultsService) private readonly defaults: WorkspaceDefaultsService,
   ) {}
 
   @Get('me')
   async me(@CurrentRequest() req: AppRequest) {
     const user = await this.prisma.user.findUniqueOrThrow({ where: { id: req.user.sub } });
-    await this.domain.ensureDefaultWorkspaceForUser(user.id);
+    await this.defaults.ensureDefaultWorkspaceForUser(user.id);
     return user;
   }
 
   @Get('me/reminder-preferences')
   async reminderPreferences(@CurrentRequest() req: AppRequest) {
-    await this.domain.ensureDefaultWorkspaceForUser(req.user.sub);
+    await this.defaults.ensureDefaultWorkspaceForUser(req.user.sub);
     const preferences = await this.prisma.userReminderPreference.findUnique({
       where: { userId: req.user.sub },
     });
@@ -58,7 +60,7 @@ export class WorkspacesController {
       throw new BadRequestException('enabled or defaultLeadTimeMinutes is required');
     }
 
-    await this.domain.ensureDefaultWorkspaceForUser(req.user.sub);
+    await this.defaults.ensureDefaultWorkspaceForUser(req.user.sub);
     return this.prisma.$transaction(async (tx) => {
       const existing = await tx.userReminderPreference.findUnique({
         where: { userId: req.user.sub },
@@ -82,7 +84,7 @@ export class WorkspacesController {
             },
           });
 
-      await this.domain.appendAuditOutbox({
+      await this.auditOutbox.appendAuditOutbox({
         tx,
         actor: req.user.sub,
         entityType: 'UserReminderPreference',
@@ -105,7 +107,7 @@ export class WorkspacesController {
 
   @Get('workspaces')
   async workspaces(@CurrentRequest() req: AppRequest) {
-    await this.domain.ensureDefaultWorkspaceForUser(req.user.sub);
+    await this.defaults.ensureDefaultWorkspaceForUser(req.user.sub);
     const memberships = await this.prisma.workspaceMembership.findMany({
       where: { userId: req.user.sub },
       include: { workspace: true },

--- a/apps/core-api/test/audit-outbox.service.test.ts
+++ b/apps/core-api/test/audit-outbox.service.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from 'vitest';
+import { Prisma } from '@prisma/client';
+import { AuditOutboxService } from '../src/common/audit-outbox.service';
+
+describe('AuditOutboxService', () => {
+  it('serializes Date values before writing JSON columns', async () => {
+    const tx = {
+      auditEvent: { create: vi.fn() },
+      outboxEvent: { create: vi.fn() },
+    };
+    const service = new AuditOutboxService();
+    const createdAt = new Date('2026-04-15T12:34:56.000Z');
+
+    await service.appendAuditOutbox({
+      tx: tx as any,
+      actor: 'user-1',
+      entityType: 'Project',
+      entityId: 'project-1',
+      action: 'project.updated',
+      beforeJson: { createdAt },
+      afterJson: { nested: { createdAt } },
+      correlationId: 'corr-1',
+      outboxType: 'project.updated',
+      payload: { createdAt },
+    });
+
+    expect(tx.auditEvent.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        beforeJson: { createdAt: createdAt.toISOString() },
+        afterJson: { nested: { createdAt: createdAt.toISOString() } },
+      }),
+    });
+    expect(tx.outboxEvent.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        payload: { createdAt: createdAt.toISOString() },
+      }),
+    });
+  });
+
+  it('preserves undefined and null JSON semantics', async () => {
+    const tx = {
+      auditEvent: { create: vi.fn() },
+      outboxEvent: { create: vi.fn() },
+    };
+    const service = new AuditOutboxService();
+
+    await service.appendAuditOutbox({
+      tx: tx as any,
+      actor: 'user-1',
+      entityType: 'Project',
+      entityId: 'project-1',
+      action: 'project.updated',
+      beforeJson: undefined,
+      afterJson: null,
+      correlationId: 'corr-1',
+      outboxType: 'project.updated',
+      payload: null,
+    });
+
+    expect(tx.auditEvent.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        beforeJson: undefined,
+        afterJson: Prisma.JsonNull,
+      }),
+    });
+    expect(tx.outboxEvent.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        payload: Prisma.JsonNull,
+      }),
+    });
+  });
+});

--- a/apps/core-api/test/domain.default-workspace.service.test.ts
+++ b/apps/core-api/test/domain.default-workspace.service.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from 'vitest';
+import { WorkspaceRole } from '@prisma/client';
+import { WorkspaceDefaultsService } from '../src/common/workspace-defaults.service';
+
+describe('WorkspaceDefaultsService default workspace bootstrap', () => {
+  it('returns an existing membership workspace after a retryable transaction conflict', async () => {
+    const workspace = {
+      id: 'workspace-1',
+      name: 'Default Workspace',
+    };
+    const prisma = {
+      $transaction: vi.fn().mockRejectedValue({
+        code: 'P2034',
+        message: 'write conflict during serializable transaction',
+      }),
+      workspaceMembership: {
+        findFirst: vi.fn().mockResolvedValue({
+          id: 'membership-1',
+          workspaceId: workspace.id,
+          userId: 'user-1',
+          role: WorkspaceRole.WS_ADMIN,
+          workspace,
+        }),
+      },
+    };
+
+    const domain = new WorkspaceDefaultsService(prisma as any, { appendAuditOutbox: vi.fn() } as any);
+
+    await expect(domain.ensureDefaultWorkspaceForUser('user-1')).resolves.toEqual(workspace);
+    expect(prisma.$transaction).toHaveBeenCalledTimes(1);
+    expect(prisma.workspaceMembership.findFirst).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/core-api/test/domain.default-workspace.service.test.ts
+++ b/apps/core-api/test/domain.default-workspace.service.test.ts
@@ -177,4 +177,49 @@ describe('WorkspaceDefaultsService project defaults', () => {
       payload: updatedRule,
     });
   });
+
+  it('does not update an existing template when only JSON property order differs', async () => {
+    const reorderedDefinition = {
+      actions: [{ status: 'DONE', type: 'setStatus' }, { type: 'setCompletedAtNow' }],
+      conditions: [{ value: 100, op: 'eq', field: 'progressPercent' }],
+      logicalOperator: 'AND',
+      trigger: 'task.progress.changed',
+    };
+    const tx = {
+      section: {
+        findFirst: vi.fn().mockResolvedValue({ id: 'section-1', projectId: 'project-1', isDefault: true }),
+      },
+      rule: {
+        findUnique: vi
+          .fn()
+          .mockResolvedValueOnce({
+            id: 'rule-1',
+            projectId: 'project-1',
+            name: 'Progress to Done',
+            templateKey: 'progress_to_done',
+            definition: reorderedDefinition,
+            enabled: true,
+            cooldownSec: 60,
+          })
+          .mockResolvedValueOnce({
+            id: 'rule-2',
+            projectId: 'project-1',
+            name: 'Progress to In Progress',
+            templateKey: 'progress_to_in_progress',
+            definition: templateDefinition('progress_to_in_progress'),
+            enabled: true,
+            cooldownSec: 60,
+          }),
+        update: vi.fn(),
+        create: vi.fn(),
+      },
+    };
+    const auditOutbox = { appendAuditOutbox: vi.fn() };
+    const service = new WorkspaceDefaultsService({} as any, auditOutbox as any);
+
+    await service.ensureProjectDefaultsInTx(tx as any, 'project-1', 'user-1', 'corr-1');
+
+    expect(tx.rule.update).not.toHaveBeenCalled();
+    expect(auditOutbox.appendAuditOutbox).not.toHaveBeenCalled();
+  });
 });

--- a/apps/core-api/test/domain.default-workspace.service.test.ts
+++ b/apps/core-api/test/domain.default-workspace.service.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { WorkspaceRole } from '@prisma/client';
 import { WorkspaceDefaultsService } from '../src/common/workspace-defaults.service';
+import { templateDefinition } from '../src/rules/rule-definition';
 
 describe('WorkspaceDefaultsService default workspace bootstrap', () => {
   it('returns an existing membership workspace after a retryable transaction conflict', async () => {
@@ -29,5 +30,106 @@ describe('WorkspaceDefaultsService default workspace bootstrap', () => {
     await expect(domain.ensureDefaultWorkspaceForUser('user-1')).resolves.toEqual(workspace);
     expect(prisma.$transaction).toHaveBeenCalledTimes(1);
     expect(prisma.workspaceMembership.findFirst).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('WorkspaceDefaultsService project defaults', () => {
+  it('runs project default provisioning inside a transaction', async () => {
+    const existingRules = {
+      progress_to_done: {
+        id: 'rule-1',
+        projectId: 'project-1',
+        templateKey: 'progress_to_done',
+        definition: templateDefinition('progress_to_done'),
+      },
+      progress_to_in_progress: {
+        id: 'rule-2',
+        projectId: 'project-1',
+        templateKey: 'progress_to_in_progress',
+        definition: templateDefinition('progress_to_in_progress'),
+      },
+    };
+    const tx = {
+      section: {
+        findFirst: vi.fn().mockResolvedValue({ id: 'section-1', projectId: 'project-1', isDefault: true }),
+      },
+      rule: {
+        findUnique: vi.fn().mockImplementation(({ where: { projectId_templateKey } }) =>
+          Promise.resolve(existingRules[projectId_templateKey.templateKey as keyof typeof existingRules]),
+        ),
+        update: vi.fn(),
+        create: vi.fn(),
+      },
+    };
+    const prisma = {
+      $transaction: vi.fn(async (callback: (txArg: typeof tx) => Promise<void>) => callback(tx)),
+    };
+    const auditOutbox = { appendAuditOutbox: vi.fn() };
+    const service = new WorkspaceDefaultsService(prisma as any, auditOutbox as any);
+
+    await service.ensureProjectDefaults('project-1', 'user-1', 'corr-1');
+
+    expect(prisma.$transaction).toHaveBeenCalledTimes(1);
+    expect(tx.section.findFirst).toHaveBeenCalledTimes(1);
+    expect(auditOutbox.appendAuditOutbox).not.toHaveBeenCalled();
+  });
+
+  it('emits rule.updated instead of rule.created when repairing an existing template', async () => {
+    const existingRule = {
+      id: 'rule-1',
+      projectId: 'project-1',
+      name: 'Progress to Done',
+      templateKey: 'progress_to_done',
+      definition: null,
+      enabled: true,
+      cooldownSec: 60,
+    };
+    const updatedRule = {
+      ...existingRule,
+      definition: templateDefinition('progress_to_done'),
+    };
+    const tx = {
+      section: {
+        findFirst: vi.fn().mockResolvedValue({ id: 'section-1', projectId: 'project-1', isDefault: true }),
+      },
+      rule: {
+        findUnique: vi
+          .fn()
+          .mockResolvedValueOnce(existingRule)
+          .mockResolvedValueOnce({
+            id: 'rule-2',
+            projectId: 'project-1',
+            name: 'Progress to In Progress',
+            templateKey: 'progress_to_in_progress',
+            definition: templateDefinition('progress_to_in_progress'),
+            enabled: true,
+            cooldownSec: 60,
+          }),
+        update: vi.fn().mockResolvedValue(updatedRule),
+        create: vi.fn(),
+      },
+    };
+    const auditOutbox = { appendAuditOutbox: vi.fn() };
+    const service = new WorkspaceDefaultsService({} as any, auditOutbox as any);
+
+    await service.ensureProjectDefaultsInTx(tx as any, 'project-1', 'user-1', 'corr-1');
+
+    expect(tx.rule.update).toHaveBeenCalledWith({
+      where: { id: existingRule.id },
+      data: { definition: templateDefinition('progress_to_done') },
+    });
+    expect(auditOutbox.appendAuditOutbox).toHaveBeenCalledTimes(1);
+    expect(auditOutbox.appendAuditOutbox).toHaveBeenCalledWith({
+      tx,
+      actor: 'user-1',
+      entityType: 'Rule',
+      entityId: updatedRule.id,
+      action: 'rule.ensure_template',
+      beforeJson: existingRule,
+      afterJson: updatedRule,
+      correlationId: 'corr-1',
+      outboxType: 'rule.updated',
+      payload: updatedRule,
+    });
   });
 });

--- a/apps/core-api/test/domain.default-workspace.service.test.ts
+++ b/apps/core-api/test/domain.default-workspace.service.test.ts
@@ -70,8 +70,53 @@ describe('WorkspaceDefaultsService project defaults', () => {
     await service.ensureProjectDefaults('project-1', 'user-1', 'corr-1');
 
     expect(prisma.$transaction).toHaveBeenCalledTimes(1);
+    expect(prisma.$transaction).toHaveBeenCalledWith(expect.any(Function), {
+      maxWait: 5000,
+      timeout: 10000,
+      isolationLevel: 'Serializable',
+    });
     expect(tx.section.findFirst).toHaveBeenCalledTimes(1);
     expect(auditOutbox.appendAuditOutbox).not.toHaveBeenCalled();
+  });
+
+  it('retries project default provisioning after a serializable transaction conflict', async () => {
+    const tx = {
+      section: {
+        findFirst: vi.fn().mockResolvedValue({ id: 'section-1', projectId: 'project-1', isDefault: true }),
+      },
+      rule: {
+        findUnique: vi
+          .fn()
+          .mockResolvedValueOnce({
+            id: 'rule-1',
+            projectId: 'project-1',
+            name: 'Progress to Done',
+            templateKey: 'progress_to_done',
+            definition: templateDefinition('progress_to_done'),
+          })
+          .mockResolvedValueOnce({
+            id: 'rule-2',
+            projectId: 'project-1',
+            name: 'Progress to In Progress',
+            templateKey: 'progress_to_in_progress',
+            definition: templateDefinition('progress_to_in_progress'),
+          }),
+        update: vi.fn(),
+        create: vi.fn(),
+      },
+    };
+    const prisma = {
+      $transaction: vi
+        .fn()
+        .mockRejectedValueOnce({ code: 'P2034', message: 'serialization failure' })
+        .mockImplementationOnce(async (callback: (txArg: typeof tx) => Promise<void>) => callback(tx)),
+    };
+    const auditOutbox = { appendAuditOutbox: vi.fn() };
+    const service = new WorkspaceDefaultsService(prisma as any, auditOutbox as any);
+
+    await expect(service.ensureProjectDefaults('project-1', 'user-1', 'corr-1')).resolves.toBeUndefined();
+    expect(prisma.$transaction).toHaveBeenCalledTimes(2);
+    expect(tx.section.findFirst).toHaveBeenCalledTimes(1);
   });
 
   it('emits rule.updated instead of rule.created when repairing an existing template', async () => {

--- a/apps/core-api/test/domain.guest-authorization.service.test.ts
+++ b/apps/core-api/test/domain.guest-authorization.service.test.ts
@@ -1,9 +1,9 @@
 import { ForbiddenException, NotFoundException } from '@nestjs/common';
 import { GuestAccessStatus, ProjectRole, WorkspaceRole } from '@prisma/client';
 import { describe, expect, it, vi } from 'vitest';
-import { DomainService } from '../src/common/domain.service';
+import { AuthorizationService } from '../src/common/authorization.service';
 
-describe('DomainService guest authorization', () => {
+describe('AuthorizationService guest authorization', () => {
   it('allows a project-scoped active guest grant to satisfy project access', async () => {
     const prisma = {
       workspaceMembership: {
@@ -27,7 +27,7 @@ describe('DomainService guest authorization', () => {
       },
     };
 
-    const domain = new DomainService(prisma as any);
+    const domain = new AuthorizationService(prisma as any);
 
     await expect(domain.requireProjectRole('project-1', 'guest-1', ProjectRole.VIEWER)).resolves.toMatchObject({
       projectId: 'project-1',
@@ -72,7 +72,7 @@ describe('DomainService guest authorization', () => {
       },
     };
 
-    const domain = new DomainService(prisma as any);
+    const domain = new AuthorizationService(prisma as any);
 
     await expect(domain.requireProjectRole('project-1', 'guest-1', ProjectRole.VIEWER)).rejects.toBeInstanceOf(
       ForbiddenException,
@@ -105,7 +105,7 @@ describe('DomainService guest authorization', () => {
       },
     };
 
-    const domain = new DomainService(prisma as any);
+    const domain = new AuthorizationService(prisma as any);
 
     await expect(domain.requireWorkspaceRole('workspace-1', 'guest-1', WorkspaceRole.WS_MEMBER)).rejects.toBeInstanceOf(
       NotFoundException,

--- a/apps/core-api/test/identity.service.test.ts
+++ b/apps/core-api/test/identity.service.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi } from 'vitest';
+import { UserStatus } from '@prisma/client';
+import { IdentityService } from '../src/common/identity.service';
+
+describe('IdentityService.ensureUser', () => {
+  it('preserves an existing email when the caller omits one', async () => {
+    const existingUser = {
+      id: 'user-1',
+      email: 'existing@example.com',
+      displayName: 'Existing User',
+      status: UserStatus.ACTIVE,
+    };
+    const prisma = {
+      user: {
+        findUnique: vi.fn().mockResolvedValue(existingUser),
+        update: vi.fn().mockResolvedValue(existingUser),
+      },
+    };
+    const service = new IdentityService(prisma as any);
+
+    await service.ensureUser('user-1');
+
+    expect(prisma.user.update).toHaveBeenCalledWith({
+      where: { id: 'user-1' },
+      data: { displayName: 'Existing User' },
+    });
+  });
+});

--- a/apps/core-api/test/identity.service.test.ts
+++ b/apps/core-api/test/identity.service.test.ts
@@ -3,6 +3,25 @@ import { UserStatus } from '@prisma/client';
 import { IdentityService } from '../src/common/identity.service';
 
 describe('IdentityService.ensureUser', () => {
+  it('skips Prisma update when there are no user fields to change', async () => {
+    const existingUser = {
+      id: 'user-1',
+      email: 'existing@example.com',
+      displayName: null,
+      status: UserStatus.ACTIVE,
+    };
+    const prisma = {
+      user: {
+        findUnique: vi.fn().mockResolvedValue(existingUser),
+        update: vi.fn(),
+      },
+    };
+    const service = new IdentityService(prisma as any);
+
+    await expect(service.ensureUser('user-1')).resolves.toEqual(existingUser);
+    expect(prisma.user.update).not.toHaveBeenCalled();
+  });
+
   it('preserves an existing email when the caller omits one', async () => {
     const existingUser = {
       id: 'user-1',
@@ -18,11 +37,7 @@ describe('IdentityService.ensureUser', () => {
     };
     const service = new IdentityService(prisma as any);
 
-    await service.ensureUser('user-1');
-
-    expect(prisma.user.update).toHaveBeenCalledWith({
-      where: { id: 'user-1' },
-      data: { displayName: 'Existing User' },
-    });
+    await expect(service.ensureUser('user-1')).resolves.toEqual(existingUser);
+    expect(prisma.user.update).not.toHaveBeenCalled();
   });
 });

--- a/apps/core-api/test/recurring-tasks.controller.test.ts
+++ b/apps/core-api/test/recurring-tasks.controller.test.ts
@@ -10,11 +10,14 @@ describe('RecurringTasksController', () => {
         findFirst: vi.fn(),
       },
     };
-    const domain = {
+    const auditOutbox = {
+      appendAuditOutbox: vi.fn(),
+    };
+    const authorization = {
       requireProjectRole: vi.fn(),
     };
 
-    const controller = new RecurringTasksController(prisma as any, domain as any);
+    const controller = new RecurringTasksController(prisma as any, auditOutbox as any, authorization as any);
 
     await expect(
       controller.update(
@@ -42,11 +45,14 @@ describe('RecurringTasksController', () => {
       },
       $transaction: vi.fn().mockRejectedValue(uniqueError),
     };
-    const domain = {
+    const auditOutbox = {
+      appendAuditOutbox: vi.fn(),
+    };
+    const authorization = {
       requireProjectRole: vi.fn().mockResolvedValue(undefined),
     };
 
-    const controller = new RecurringTasksController(prisma as any, domain as any);
+    const controller = new RecurringTasksController(prisma as any, auditOutbox as any, authorization as any);
 
     await expect(
       controller.create(

--- a/apps/core-api/test/task-attachments.service.test.ts
+++ b/apps/core-api/test/task-attachments.service.test.ts
@@ -32,13 +32,21 @@ describe('TaskAttachmentsService', () => {
         updateMany: vi.fn().mockResolvedValue({ count: 0 }),
       },
     };
-    const domain = {
+    const auditOutbox = {
+      appendAuditOutbox: vi.fn(),
+    };
+    const authorization = {
       requireProjectRole: vi.fn().mockResolvedValue(undefined),
     };
     const downloadUrls = {
       buildUrl: vi.fn(),
     };
-    const service = new TaskAttachmentsService(prisma as any, domain as any, downloadUrls as any);
+    const service = new TaskAttachmentsService(
+      prisma as any,
+      auditOutbox as any,
+      authorization as any,
+      downloadUrls as any,
+    );
     const uploadPath = path.join(storageDir, 'task-1', 'race.png');
 
     await expect(

--- a/apps/core-api/test/task-comments.service.test.ts
+++ b/apps/core-api/test/task-comments.service.test.ts
@@ -14,8 +14,10 @@ describe('TaskCommentsService', () => {
       },
       $transaction: vi.fn(),
     };
-    const domain = {
+    const authorization = {
       requireProjectRole: vi.fn().mockResolvedValue(undefined),
+    };
+    const auditOutbox = {
       appendAuditOutbox: vi.fn(),
     };
     const notifications = {
@@ -25,7 +27,13 @@ describe('TaskCommentsService', () => {
       syncTaskMentions: vi.fn(),
       extractMentionUserIdsFromComment: vi.fn(),
     };
-    const service = new TaskCommentsService(prisma as any, domain as any, notifications as any, mentions as any);
+    const service = new TaskCommentsService(
+      prisma as any,
+      auditOutbox as any,
+      authorization as any,
+      notifications as any,
+      mentions as any,
+    );
 
     await expect(
       service.createComment(
@@ -36,7 +44,7 @@ describe('TaskCommentsService', () => {
     ).rejects.toThrow(ConflictException);
 
     expect(prisma.task.findFirstOrThrow).toHaveBeenCalledTimes(1);
-    expect(domain.requireProjectRole).toHaveBeenCalledTimes(1);
+    expect(authorization.requireProjectRole).toHaveBeenCalledTimes(1);
     expect(prisma.$transaction).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- extract focused common services for identity bootstrap, authorization, workspace defaults, and audit/outbox writes
- migrate remaining `core-api` consumers away from `DomainService` for auth and audit concerns
- trim `DomainService` down to task and rule domain helper logic plus focused tests for the new seams

## Why
`DomainService` had become a cross-cutting dependency for unrelated concerns. This split keeps the behavior the same while narrowing constructor coupling and making the common-service boundaries reviewable.

## Impact
- controllers and services now depend on `AuthorizationService` and `AuditOutboxService` directly where appropriate
- default-workspace and identity bootstrap behavior now live behind dedicated common services
- tests that instantiate affected classes directly were updated to match the new constructor boundaries

## Validation
- `pnpm --filter @atlaspm/core-api type-check`
- `pnpm --filter @atlaspm/core-api lint`
- `pnpm --filter @atlaspm/core-api exec vitest run test/domain.default-workspace.service.test.ts test/domain.guest-authorization.service.test.ts test/recurring-task.worker.test.ts test/recurring-tasks.controller.test.ts test/task-attachments.service.test.ts test/task-comments.service.test.ts test/task-dependencies-slice.test.ts test/task-reminders-slice.test.ts test/goals.integration.test.ts test/capacity.integration.test.ts`

Closes #391


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Core backend reorganized: authorization, audit/outbox, identity, and workspace-defaults consolidated into shared global services; the legacy domain service reduced to helpers. Many server components now use the new shared services; behavior and public APIs remain unchanged.

* **Tests**
  * New and updated tests added to validate authorization, audit/outbox, identity sync, and default workspace/project provisioning with retry behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->