### PR TITLE
[codex] Extract timeline view-model helpers

### DIFF
--- a/apps/web-ui/src/components/project-timeline-view-model.test.ts
+++ b/apps/web-ui/src/components/project-timeline-view-model.test.ts
@@ -58,21 +58,25 @@ function buildViewModel(args: {
   tasks: TimelineTask[];
   dependencyEdges?: DependencyGraphEdge[];
   mode?: TimelineMode;
+  search?: string;
+  statusFilter?: 'ALL' | Task['status'];
+  priorityFilter?: 'ALL' | NonNullable<Task['priority']>;
   scheduleFilter?: TimelineScheduleFilter;
   sortMode?: TimelineSortMode;
   ganttRiskFilterMode?: 'all' | 'risk';
+  today?: Date;
 }) {
   return buildTimelineTaskViewModel({
     tasks: args.tasks,
     dependencyEdges: args.dependencyEdges ?? [],
     mode: args.mode ?? 'timeline',
-    search: '',
-    statusFilter: 'ALL',
-    priorityFilter: 'ALL',
+    search: args.search ?? '',
+    statusFilter: args.statusFilter ?? 'ALL',
+    priorityFilter: args.priorityFilter ?? 'ALL',
     effectiveScheduleFilter: args.scheduleFilter ?? 'all',
     effectiveSortMode: args.sortMode ?? 'manual',
     ganttRiskFilterMode: args.ganttRiskFilterMode ?? 'all',
-    today: new Date('2026-03-10T09:00:00.000Z'),
+    today: args.today ?? new Date('2026-03-10T09:00:00.000Z'),
   });
 }
 
@@ -140,6 +144,53 @@ describe('project timeline view model', () => {
     });
   });
 
+  test('keeps gantt risk metadata from blockers that are filtered out of the visible task list', () => {
+    const blocker = createTask({
+      id: 'task-blocker',
+      title: 'Hidden blocker',
+      status: 'IN_PROGRESS',
+      startAt: '2026-03-01T00:00:00.000Z',
+      dueAt: '2026-03-04T00:00:00.000Z',
+      timelineStart: new Date('2026-03-01T00:00:00.000Z'),
+      timelineEnd: new Date('2026-03-04T00:00:00.000Z'),
+      hasSchedule: true,
+      inWindow: true,
+    });
+    const target = createTask({
+      id: 'task-target',
+      title: 'Visible target',
+      status: 'TODO',
+      startAt: '2026-03-05T00:00:00.000Z',
+      dueAt: '2026-03-06T00:00:00.000Z',
+      timelineStart: new Date('2026-03-05T00:00:00.000Z'),
+      timelineEnd: new Date('2026-03-06T00:00:00.000Z'),
+      hasSchedule: true,
+      inWindow: true,
+    });
+
+    const viewModel = buildViewModel({
+      tasks: [blocker, target],
+      dependencyEdges: [
+        { source: 'task-blocker', target: 'task-target', type: 'BLOCKS' } as DependencyGraphEdge,
+      ],
+      mode: 'gantt',
+      statusFilter: 'TODO',
+      scheduleFilter: 'scheduled',
+      ganttRiskFilterMode: 'risk',
+      today: new Date('2026-03-01T00:00:00.000Z'),
+    });
+
+    expect(viewModel.baseFilteredTasks.map((task) => task.id)).toEqual(['task-target']);
+    expect(viewModel.filteredTasks.map((task) => task.id)).toEqual(['task-target']);
+    expect(viewModel.ganttRiskTasks.map((task) => task.id)).toEqual(['task-target']);
+    expect(viewModel.ganttRiskByTaskId.get('task-target')).toEqual({
+      isAtRisk: true,
+      overdue: false,
+      blockedByOpen: 1,
+      blockedByLate: 0,
+    });
+  });
+
   test('normalizes legacy and malformed manual layout state', () => {
     const state = normalizeTimelineManualLayoutState({
       section: {
@@ -153,7 +204,16 @@ describe('project timeline view model', () => {
           },
         },
       },
-      assignee: [],
+      assignee: {
+        'assignee:user-1': {
+          taskOrder: [' task-6 ', 'task-7', 'task-6'],
+          rowByTaskId: {
+            ' task-6 ': 1,
+            'task-7': 9,
+            'task-8': 0,
+          },
+        },
+      },
       status: {
         'status:TODO': ['task-4', 'task-5'],
       },
@@ -169,7 +229,15 @@ describe('project timeline view model', () => {
           },
         },
       },
-      assignee: {},
+      assignee: {
+        'assignee:user-1': {
+          orderedTaskIds: ['task-6', 'task-7'],
+          rowByTaskId: {
+            'task-6': 1,
+            'task-7': 1,
+          },
+        },
+      },
       status: {
         'status:TODO': {
           orderedTaskIds: ['task-4', 'task-5'],

--- a/apps/web-ui/src/components/project-timeline-view-model.test.ts
+++ b/apps/web-ui/src/components/project-timeline-view-model.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, test } from 'vitest';
+import type { TimelineTask } from '@/hooks/use-timeline-data';
+import type { DependencyGraphEdge, Section, Task } from '@/lib/types';
+import {
+  buildTimelineTaskViewModel,
+  normalizeTimelineManualLayoutState,
+  type TimelineMode,
+  type TimelineScheduleFilter,
+  type TimelineSortMode,
+} from './project-timeline-view-model';
+
+const defaultSection: Section = {
+  id: 'default',
+  projectId: 'project-1',
+  name: 'Default',
+  position: 1000,
+  isDefault: true,
+};
+
+function createTask(overrides: Partial<TimelineTask> = {}): TimelineTask {
+  const baseTask = {
+    id: 'task-1',
+    projectId: 'project-1',
+    sectionId: 'default',
+    title: 'Task',
+    status: 'TODO',
+    type: 'TASK',
+    progressPercent: 0,
+    priority: 'MEDIUM',
+    position: 1000,
+    version: 1,
+    assigneeUserId: null,
+    description: null,
+    startAt: null,
+    dueAt: null,
+    completedAt: null,
+    parentId: null,
+    customFieldValues: [],
+    baselineStartAt: null,
+    baselineDueAt: null,
+    section: defaultSection,
+    timelineStart: null,
+    timelineEnd: null,
+    baselineStart: null,
+    baselineEnd: null,
+    hasSchedule: false,
+    hasBaseline: false,
+    inWindow: false,
+  } satisfies Partial<Task> & Partial<TimelineTask>;
+
+  return {
+    ...baseTask,
+    ...overrides,
+  } as TimelineTask;
+}
+
+function buildViewModel(args: {
+  tasks: TimelineTask[];
+  dependencyEdges?: DependencyGraphEdge[];
+  mode?: TimelineMode;
+  scheduleFilter?: TimelineScheduleFilter;
+  sortMode?: TimelineSortMode;
+  ganttRiskFilterMode?: 'all' | 'risk';
+}) {
+  return buildTimelineTaskViewModel({
+    tasks: args.tasks,
+    dependencyEdges: args.dependencyEdges ?? [],
+    mode: args.mode ?? 'timeline',
+    search: '',
+    statusFilter: 'ALL',
+    priorityFilter: 'ALL',
+    effectiveScheduleFilter: args.scheduleFilter ?? 'all',
+    effectiveSortMode: args.sortMode ?? 'manual',
+    ganttRiskFilterMode: args.ganttRiskFilterMode ?? 'all',
+    today: new Date('2026-03-10T09:00:00.000Z'),
+  });
+}
+
+describe('project timeline view model', () => {
+  test('filters scheduled timeline tasks and derives gantt risk summaries', () => {
+    const blocker = createTask({
+      id: 'task-blocker',
+      title: 'Blocker',
+      status: 'IN_PROGRESS',
+      startAt: '2026-03-01T00:00:00.000Z',
+      dueAt: '2026-03-08T00:00:00.000Z',
+      timelineStart: new Date('2026-03-01T00:00:00.000Z'),
+      timelineEnd: new Date('2026-03-08T00:00:00.000Z'),
+      hasSchedule: true,
+      inWindow: true,
+    });
+    const target = createTask({
+      id: 'task-target',
+      title: 'Target',
+      status: 'TODO',
+      startAt: '2026-03-05T00:00:00.000Z',
+      dueAt: '2026-03-06T00:00:00.000Z',
+      timelineStart: new Date('2026-03-05T00:00:00.000Z'),
+      timelineEnd: new Date('2026-03-06T00:00:00.000Z'),
+      baselineStart: new Date('2026-03-04T00:00:00.000Z'),
+      baselineEnd: new Date('2026-03-05T00:00:00.000Z'),
+      baselineStartAt: '2026-03-04T00:00:00.000Z',
+      baselineDueAt: '2026-03-05T00:00:00.000Z',
+      hasSchedule: true,
+      hasBaseline: true,
+      inWindow: true,
+    });
+    const unscheduled = createTask({
+      id: 'task-unscheduled',
+      title: 'Inbox',
+      hasSchedule: false,
+      inWindow: false,
+    });
+
+    const viewModel = buildViewModel({
+      tasks: [unscheduled, target, blocker],
+      dependencyEdges: [
+        { source: 'task-blocker', target: 'task-target', type: 'BLOCKS' } as DependencyGraphEdge,
+        { source: 'task-unscheduled', target: 'task-target', type: 'RELATES_TO' } as DependencyGraphEdge,
+      ],
+      mode: 'gantt',
+      scheduleFilter: 'scheduled',
+      sortMode: 'dueAt',
+      ganttRiskFilterMode: 'risk',
+    });
+
+    expect(viewModel.baseFilteredTasks.map((task) => task.id)).toEqual(['task-target', 'task-blocker']);
+    expect(viewModel.filteredTasks.map((task) => task.id)).toEqual(['task-target', 'task-blocker']);
+    expect(viewModel.scheduledTimelineTasks.map((task) => task.id)).toEqual(['task-target', 'task-blocker']);
+    expect(viewModel.ganttRiskTasks.map((task) => task.id)).toEqual(['task-target', 'task-blocker']);
+    expect(viewModel.ganttBlockedTasks.map((task) => task.id)).toEqual(['task-target']);
+    expect(viewModel.ganttDelayedTasks.map((task) => task.id)).toEqual(['task-target']);
+    expect(viewModel.ganttAheadTasks).toEqual([]);
+    expect(viewModel.totalDependencyEdges).toBe(1);
+    expect(viewModel.ganttRiskByTaskId.get('task-target')).toEqual({
+      isAtRisk: true,
+      overdue: true,
+      blockedByOpen: 1,
+      blockedByLate: 1,
+    });
+  });
+
+  test('normalizes legacy and malformed manual layout state', () => {
+    const state = normalizeTimelineManualLayoutState({
+      section: {
+        'section:default': {
+          taskIds: [' task-1 ', 'task-2', 'task-1', '', null],
+          rowHints: {
+            ' task-1 ': 2,
+            'task-2': 9,
+            'task-3': 1,
+            '': 4,
+          },
+        },
+      },
+      assignee: [],
+      status: {
+        'status:TODO': ['task-4', 'task-5'],
+      },
+    });
+
+    expect(state).toEqual({
+      section: {
+        'section:default': {
+          orderedTaskIds: ['task-1', 'task-2'],
+          rowByTaskId: {
+            'task-1': 1,
+            'task-2': 1,
+          },
+        },
+      },
+      assignee: {},
+      status: {
+        'status:TODO': {
+          orderedTaskIds: ['task-4', 'task-5'],
+        },
+      },
+    });
+  });
+});

--- a/apps/web-ui/src/components/project-timeline-view-model.ts
+++ b/apps/web-ui/src/components/project-timeline-view-model.ts
@@ -176,7 +176,7 @@ export function buildTimelineTaskViewModel(input: BuildTimelineTaskViewModelInpu
     .sort((left, right) => compareTimelineTasks(left, right, input.effectiveSortMode));
 
   const ganttRiskByTaskId = buildGanttRiskByTaskId(
-    baseFilteredTasks,
+    input.tasks,
     input.dependencyEdges,
     input.today,
   );
@@ -237,6 +237,8 @@ export function normalizeTimelineManualLayoutByLane(value: unknown): TimelineMan
           ? {
               orderedTaskIds: Array.isArray((rawTaskIds as Record<string, unknown>).orderedTaskIds)
                 ? ((rawTaskIds as Record<string, unknown>).orderedTaskIds as unknown[])
+                : Array.isArray((rawTaskIds as Record<string, unknown>).taskOrder)
+                  ? ((rawTaskIds as Record<string, unknown>).taskOrder as unknown[])
                 : Array.isArray((rawTaskIds as Record<string, unknown>).taskIds)
                   ? ((rawTaskIds as Record<string, unknown>).taskIds as unknown[])
                   : [],

--- a/apps/web-ui/src/components/project-timeline-view-model.ts
+++ b/apps/web-ui/src/components/project-timeline-view-model.ts
@@ -1,0 +1,465 @@
+import type { ProjectViewState as SavedProjectViewState } from '@atlaspm/domain';
+import { normalizeProjectViewState } from '@atlaspm/domain';
+import type { TimelineTask } from '@/hooks/use-timeline-data';
+import type { DependencyGraphEdge, SectionTaskGroup, Task } from '@/lib/types';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export type TimelineZoom = 'day' | 'week' | 'month';
+export type TimelineMode = 'timeline' | 'gantt';
+export type TimelineSwimlane = 'section' | 'assignee' | 'status';
+export type TimelineSortMode = 'manual' | 'startAt' | 'dueAt';
+export type TimelineScheduleFilter = 'all' | 'scheduled' | 'unscheduled';
+export type GanttRiskFilterMode = 'all' | 'risk';
+export type TimelineLaneOrderGroupBy = Extract<TimelineSwimlane, 'section' | 'assignee'>;
+
+export type TimelineManualLaneLayout = {
+  orderedTaskIds: string[];
+  rowByTaskId?: Record<string, number>;
+};
+
+export type TimelineManualLayoutByLane = Record<string, TimelineManualLaneLayout>;
+
+export type TimelineManualLayoutState = Record<TimelineSwimlane, TimelineManualLayoutByLane>;
+
+export type TimelineViewState = {
+  zoom?: TimelineZoom;
+  anchorDate?: string;
+  swimlane?: TimelineSwimlane;
+  sortMode?: TimelineSortMode;
+  scheduleFilter?: TimelineScheduleFilter;
+  workingDaysOnly?: boolean;
+  ganttRiskFilterMode?: GanttRiskFilterMode;
+  ganttStrictMode?: boolean;
+};
+
+export type GanttTaskRisk = {
+  isAtRisk: boolean;
+  overdue: boolean;
+  blockedByOpen: number;
+  blockedByLate: number;
+};
+
+type BuildTimelineTaskViewModelInput = {
+  tasks: TimelineTask[];
+  dependencyEdges: DependencyGraphEdge[];
+  mode: TimelineMode;
+  search: string;
+  statusFilter: 'ALL' | Task['status'];
+  priorityFilter: 'ALL' | NonNullable<Task['priority']>;
+  effectiveScheduleFilter: TimelineScheduleFilter;
+  effectiveSortMode: TimelineSortMode;
+  ganttRiskFilterMode: GanttRiskFilterMode;
+  today: Date;
+};
+
+function dayNumber(date: Date): number {
+  const localMidnight = new Date(date.getFullYear(), date.getMonth(), date.getDate());
+  return Math.floor(localMidnight.getTime() / DAY_MS);
+}
+
+function dayDiff(from: Date, to: Date): number {
+  return dayNumber(to) - dayNumber(from);
+}
+
+function startOfDay(value: Date): Date {
+  return new Date(value.getFullYear(), value.getMonth(), value.getDate());
+}
+
+export function createEmptyTimelineManualLayoutState(): TimelineManualLayoutState {
+  return {
+    section: {},
+    assignee: {},
+    status: {},
+  };
+}
+
+export function compareTimelineTasks(
+  left: TimelineTask,
+  right: TimelineTask,
+  sortMode: TimelineSortMode,
+): number {
+  if (sortMode === 'startAt') {
+    const leftStart = left.timelineStart ? dayNumber(left.timelineStart) : Number.MAX_SAFE_INTEGER;
+    const rightStart = right.timelineStart
+      ? dayNumber(right.timelineStart)
+      : Number.MAX_SAFE_INTEGER;
+    if (leftStart !== rightStart) return leftStart - rightStart;
+  } else if (sortMode === 'dueAt') {
+    const leftDue = left.timelineEnd ? dayNumber(left.timelineEnd) : Number.MAX_SAFE_INTEGER;
+    const rightDue = right.timelineEnd ? dayNumber(right.timelineEnd) : Number.MAX_SAFE_INTEGER;
+    if (leftDue !== rightDue) return leftDue - rightDue;
+  }
+
+  const sectionDelta = left.section.position - right.section.position;
+  if (sectionDelta !== 0) return sectionDelta;
+  const positionDelta = left.position - right.position;
+  if (positionDelta !== 0) return positionDelta;
+  return left.title.localeCompare(right.title);
+}
+
+export function baselineVarianceDays(task: TimelineTask): number | null {
+  if (!task.baselineEnd || !task.timelineEnd) return null;
+  return dayDiff(task.baselineEnd, task.timelineEnd);
+}
+
+export function taskMatchesFilters(
+  task: Task,
+  search: string,
+  statusFilter: 'ALL' | Task['status'],
+  priorityFilter: 'ALL' | NonNullable<Task['priority']>,
+): boolean {
+  const bySearch = !search.trim() || task.title.toLowerCase().includes(search.trim().toLowerCase());
+  const byStatus = statusFilter === 'ALL' || task.status === statusFilter;
+  const byPriority = priorityFilter === 'ALL' || task.priority === priorityFilter;
+  return bySearch && byStatus && byPriority;
+}
+
+export function buildGanttRiskByTaskId(
+  tasks: TimelineTask[],
+  dependencyEdges: DependencyGraphEdge[],
+  today: Date,
+): Map<string, GanttTaskRisk> {
+  const taskById = new Map(tasks.map((task) => [task.id, task]));
+  const incomingDependenciesByTarget = new Map<string, TimelineTask[]>();
+  for (const edge of dependencyEdges) {
+    if (edge.type === 'RELATES_TO') continue;
+    const sourceTask = taskById.get(edge.source);
+    const targetTask = taskById.get(edge.target);
+    if (!sourceTask || !targetTask) continue;
+    const list = incomingDependenciesByTarget.get(edge.target) ?? [];
+    list.push(sourceTask);
+    incomingDependenciesByTarget.set(edge.target, list);
+  }
+
+  const todayDay = dayNumber(startOfDay(today));
+  const next = new Map<string, GanttTaskRisk>();
+  for (const task of tasks) {
+    const blockers = incomingDependenciesByTarget.get(task.id) ?? [];
+    let blockedByOpen = 0;
+    let blockedByLate = 0;
+    const taskDueDay = task.timelineEnd ? dayNumber(task.timelineEnd) : null;
+    for (const blocker of blockers) {
+      if (blocker.status !== 'DONE') {
+        blockedByOpen += 1;
+      }
+      if (taskDueDay !== null && blocker.timelineEnd && dayNumber(blocker.timelineEnd) > taskDueDay) {
+        blockedByLate += 1;
+      }
+    }
+
+    const overdue = Boolean(
+      task.timelineEnd && dayNumber(task.timelineEnd) < todayDay && task.status !== 'DONE',
+    );
+    const isAtRisk = overdue || blockedByOpen > 0 || blockedByLate > 0;
+    next.set(task.id, {
+      isAtRisk,
+      overdue,
+      blockedByOpen,
+      blockedByLate,
+    });
+  }
+
+  return next;
+}
+
+export function buildTimelineTaskViewModel(input: BuildTimelineTaskViewModelInput) {
+  const baseFilteredTasks = input.tasks
+    .filter((task) =>
+      taskMatchesFilters(task, input.search, input.statusFilter, input.priorityFilter),
+    )
+    .filter((task) => {
+      if (input.effectiveScheduleFilter === 'scheduled') return task.hasSchedule;
+      if (input.effectiveScheduleFilter === 'unscheduled') return !task.hasSchedule;
+      return true;
+    })
+    .sort((left, right) => compareTimelineTasks(left, right, input.effectiveSortMode));
+
+  const ganttRiskByTaskId = buildGanttRiskByTaskId(
+    baseFilteredTasks,
+    input.dependencyEdges,
+    input.today,
+  );
+
+  const filteredTasks =
+    input.mode !== 'gantt' || input.ganttRiskFilterMode === 'all'
+      ? baseFilteredTasks
+      : baseFilteredTasks.filter((task) => ganttRiskByTaskId.get(task.id)?.isAtRisk);
+
+  const scheduledTimelineTasks = filteredTasks.filter((task) => task.hasSchedule);
+  const filteredTaskIds = new Set(filteredTasks.map((task) => task.id));
+  const ganttRiskTasks = baseFilteredTasks.filter((task) => ganttRiskByTaskId.get(task.id)?.isAtRisk);
+  const ganttBlockedTasks = baseFilteredTasks.filter(
+    (task) => (ganttRiskByTaskId.get(task.id)?.blockedByOpen ?? 0) > 0,
+  );
+
+  const ganttVarianceByTaskId = new Map<string, number>();
+  for (const task of baseFilteredTasks) {
+    const variance = baselineVarianceDays(task);
+    if (variance !== null) ganttVarianceByTaskId.set(task.id, variance);
+  }
+
+  const ganttDelayedTasks = baseFilteredTasks.filter(
+    (task) => (ganttVarianceByTaskId.get(task.id) ?? 0) > 0,
+  );
+  const ganttAheadTasks = baseFilteredTasks.filter(
+    (task) => (ganttVarianceByTaskId.get(task.id) ?? 0) < 0,
+  );
+  const totalDependencyEdges = input.dependencyEdges.filter(
+    (edge) => filteredTaskIds.has(edge.source) && filteredTaskIds.has(edge.target),
+  ).length;
+
+  return {
+    baseFilteredTasks,
+    filteredTasks,
+    scheduledTimelineTasks,
+    ganttRiskByTaskId,
+    ganttRiskTasks,
+    ganttBlockedTasks,
+    ganttVarianceByTaskId,
+    ganttDelayedTasks,
+    ganttAheadTasks,
+    filteredTaskIds,
+    totalDependencyEdges,
+  };
+}
+
+export function normalizeTimelineManualLayoutByLane(value: unknown): TimelineManualLayoutByLane {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {};
+  const next: TimelineManualLayoutByLane = {};
+  for (const [laneIdRaw, rawTaskIds] of Object.entries(value as Record<string, unknown>)) {
+    const laneId = laneIdRaw.trim();
+    if (!laneId) continue;
+    const candidate =
+      Array.isArray(rawTaskIds)
+        ? { orderedTaskIds: rawTaskIds, rowByTaskId: {} as Record<string, unknown> }
+        : rawTaskIds && typeof rawTaskIds === 'object' && !Array.isArray(rawTaskIds)
+          ? {
+              orderedTaskIds: Array.isArray((rawTaskIds as Record<string, unknown>).orderedTaskIds)
+                ? ((rawTaskIds as Record<string, unknown>).orderedTaskIds as unknown[])
+                : Array.isArray((rawTaskIds as Record<string, unknown>).taskIds)
+                  ? ((rawTaskIds as Record<string, unknown>).taskIds as unknown[])
+                  : [],
+              rowByTaskId:
+                (rawTaskIds as Record<string, unknown>).rowByTaskId &&
+                typeof (rawTaskIds as Record<string, unknown>).rowByTaskId === 'object' &&
+                !Array.isArray((rawTaskIds as Record<string, unknown>).rowByTaskId)
+                  ? ((rawTaskIds as Record<string, unknown>).rowByTaskId as Record<string, unknown>)
+                  : (rawTaskIds as Record<string, unknown>).rowHints &&
+                      typeof (rawTaskIds as Record<string, unknown>).rowHints === 'object' &&
+                      !Array.isArray((rawTaskIds as Record<string, unknown>).rowHints)
+                    ? ((rawTaskIds as Record<string, unknown>).rowHints as Record<string, unknown>)
+                    : {},
+            }
+          : null;
+    if (!candidate) continue;
+
+    const seenTaskIds = new Set<string>();
+    const normalizedTaskIds: string[] = [];
+    for (const taskId of candidate.orderedTaskIds) {
+      if (typeof taskId !== 'string') continue;
+      const trimmedTaskId = taskId.trim();
+      if (!trimmedTaskId || seenTaskIds.has(trimmedTaskId)) continue;
+      seenTaskIds.add(trimmedTaskId);
+      normalizedTaskIds.push(trimmedTaskId);
+    }
+    if (normalizedTaskIds.length === 0) continue;
+
+    const normalizedTaskIdSet = new Set(normalizedTaskIds);
+    const rowByTaskId: Record<string, number> = {};
+    const maxRowIndex = Math.max(normalizedTaskIds.length - 1, 0);
+    for (const [taskIdRaw, rowIndex] of Object.entries(candidate.rowByTaskId)) {
+      const taskId = taskIdRaw.trim();
+      if (!taskId || !normalizedTaskIdSet.has(taskId)) continue;
+      const numericRowIndex = Number(rowIndex);
+      if (!Number.isInteger(numericRowIndex) || numericRowIndex < 0) continue;
+      rowByTaskId[taskId] = Math.min(numericRowIndex, maxRowIndex);
+    }
+
+    next[laneId] =
+      Object.keys(rowByTaskId).length > 0
+        ? { orderedTaskIds: normalizedTaskIds, rowByTaskId }
+        : { orderedTaskIds: normalizedTaskIds };
+  }
+  return next;
+}
+
+export function normalizeTimelineManualLayoutState(value: unknown): TimelineManualLayoutState {
+  const next = createEmptyTimelineManualLayoutState();
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return next;
+  const candidate = value as Record<string, unknown>;
+  next.section = normalizeTimelineManualLayoutByLane(candidate.section);
+  next.assignee = normalizeTimelineManualLayoutByLane(candidate.assignee);
+  next.status = normalizeTimelineManualLayoutByLane(candidate.status);
+  return next;
+}
+
+export function hasTimelineManualLayout(layout: TimelineManualLayoutByLane): boolean {
+  return Object.values(layout).some((laneTaskOrder) => laneTaskOrder.orderedTaskIds.length > 0);
+}
+
+export function mergeTimelineManualLaneTaskOrder(
+  existingLaneLayout: TimelineManualLaneLayout | undefined,
+  nextTaskOrder: string[],
+  nextRowByTaskId?: Record<string, number>,
+): TimelineManualLaneLayout {
+  const seenTaskIds = new Set(nextTaskOrder);
+  const orderedTaskIds = [
+    ...nextTaskOrder,
+    ...(existingLaneLayout?.orderedTaskIds ?? []).filter((taskId) => !seenTaskIds.has(taskId)),
+  ];
+  const rowByTaskId = {
+    ...(existingLaneLayout?.rowByTaskId ?? {}),
+    ...(nextRowByTaskId ?? {}),
+  };
+  for (const taskId of Object.keys(rowByTaskId)) {
+    if (!orderedTaskIds.includes(taskId)) delete rowByTaskId[taskId];
+  }
+  return Object.keys(rowByTaskId).length > 0 ? { orderedTaskIds, rowByTaskId } : { orderedTaskIds };
+}
+
+export function getTimelineManualOrderedTaskIdsByLane(
+  layout: TimelineManualLayoutByLane,
+): Record<string, string[]> {
+  return Object.fromEntries(
+    Object.entries(layout)
+      .filter(([, laneLayout]) => laneLayout.orderedTaskIds.length > 0)
+      .map(([laneId, laneLayout]) => [laneId, laneLayout.orderedTaskIds]),
+  );
+}
+
+export function getTimelineManualRowByTaskIdByLane(
+  layout: TimelineManualLayoutByLane,
+): Record<string, Record<string, number>> {
+  return Object.fromEntries(
+    Object.entries(layout)
+      .filter(([, laneLayout]) => Boolean(laneLayout.rowByTaskId && Object.keys(laneLayout.rowByTaskId).length))
+      .map(([laneId, laneLayout]) => [laneId, laneLayout.rowByTaskId ?? {}]),
+  );
+}
+
+export function areSavedProjectViewStatesEqual(
+  mode: TimelineMode,
+  left: SavedProjectViewState | null | undefined,
+  right: SavedProjectViewState,
+): boolean {
+  return (
+    JSON.stringify(normalizeProjectViewState(mode, left)) ===
+    JSON.stringify(normalizeProjectViewState(mode, right))
+  );
+}
+
+export function applyTaskScheduleInGroups(
+  groups: SectionTaskGroup[],
+  taskId: string,
+  next: { startAt: string | null; dueAt: string | null },
+) {
+  return groups.map((group) => ({
+    ...group,
+    tasks: group.tasks.map((task) =>
+      task.id === taskId
+        ? {
+            ...task,
+            startAt: next.startAt,
+            dueAt: next.dueAt,
+          }
+        : task,
+    ),
+  }));
+}
+
+export function applyTaskSchedulesInGroups(
+  groups: SectionTaskGroup[],
+  nextByTaskId: Map<string, { startAt: string | null; dueAt: string | null }>,
+) {
+  return groups.map((group) => ({
+    ...group,
+    tasks: group.tasks.map((task) => {
+      const next = nextByTaskId.get(task.id);
+      return next
+        ? {
+            ...task,
+            startAt: next.startAt,
+            dueAt: next.dueAt,
+          }
+        : task;
+    }),
+  }));
+}
+
+export function findTaskInGroups(groups: SectionTaskGroup[], taskId: string): Task | undefined {
+  for (const group of groups) {
+    const task = group.tasks.find((candidate) => candidate.id === taskId);
+    if (task) return task;
+  }
+  return undefined;
+}
+
+export function applyResolvedTaskInGroups(groups: SectionTaskGroup[], resolvedTask: Task) {
+  const withoutTask = groups.map((group) => ({
+    ...group,
+    tasks: group.tasks.filter((task) => task.id !== resolvedTask.id),
+  }));
+
+  return withoutTask.map((group) =>
+    group.section.id === resolvedTask.sectionId
+      ? { ...group, tasks: [...group.tasks, resolvedTask] }
+      : group,
+  );
+}
+
+export function applyResolvedTasksInGroups(groups: SectionTaskGroup[], resolvedTasks: Task[]) {
+  return resolvedTasks.reduce(
+    (current, resolvedTask) => applyResolvedTaskInGroups(current, resolvedTask),
+    groups,
+  );
+}
+
+export function applyTaskTimelineMoveInGroups(
+  groups: SectionTaskGroup[],
+  taskId: string,
+  next: {
+    startAt?: string | null;
+    dueAt?: string | null;
+    assigneeUserId?: string | null;
+    sectionId?: string;
+    status?: Task['status'];
+  },
+) {
+  let movedTask: Task | null = null;
+  const withoutTask = groups.map((group) => ({
+    ...group,
+    tasks: group.tasks.filter((task) => {
+      if (task.id !== taskId) return true;
+      const updatedTask: Task = { ...task };
+      if (next.startAt !== undefined) {
+        updatedTask.startAt = next.startAt;
+      }
+      if (next.dueAt !== undefined) {
+        updatedTask.dueAt = next.dueAt;
+      }
+      if (next.assigneeUserId !== undefined) {
+        updatedTask.assigneeUserId = next.assigneeUserId;
+      }
+      if (next.sectionId !== undefined) {
+        updatedTask.sectionId = next.sectionId;
+      }
+      if (next.status !== undefined) {
+        updatedTask.status = next.status;
+        updatedTask.completedAt =
+          next.status === 'DONE' ? (task.completedAt ?? new Date().toISOString()) : null;
+      }
+      movedTask = updatedTask;
+      return false;
+    }),
+  }));
+
+  if (!movedTask) return groups;
+  const finalizedTask: Task = movedTask;
+  const targetSectionId = next.sectionId ?? finalizedTask.sectionId;
+  return withoutTask.map((group) =>
+    group.section.id === targetSectionId
+      ? { ...group, tasks: [...group.tasks, finalizedTask] }
+      : group,
+  );
+}

--- a/apps/web-ui/src/components/project-timeline-view.tsx
+++ b/apps/web-ui/src/components/project-timeline-view.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useId, useMemo, useRef, useState, type CSSProperties } from 'react';
 import {
+  buildTimelineLaneSubtaskMeta,
   buildTimelineLanes,
   buildTimelineLayout,
   buildTimelineTaskOrderByLane,
@@ -11,11 +12,40 @@ import {
   normalizeProjectViewState,
   resolveProjectViewState,
   type ProjectViewState as SavedProjectViewState,
+  type TimelineLaneSubtaskMeta,
 } from '@atlaspm/domain';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { ChevronDown, ChevronLeft, ChevronRight } from 'lucide-react';
 import { useSearchParams } from 'next/navigation';
 import TaskDetailDrawer from '@/components/task-detail-drawer';
+import {
+  applyResolvedTaskInGroups,
+  applyResolvedTasksInGroups,
+  applyTaskScheduleInGroups,
+  applyTaskSchedulesInGroups,
+  applyTaskTimelineMoveInGroups,
+  areSavedProjectViewStatesEqual,
+  buildTimelineTaskViewModel,
+  compareTimelineTasks,
+  findTaskInGroups,
+  getTimelineManualOrderedTaskIdsByLane,
+  getTimelineManualRowByTaskIdByLane,
+  hasTimelineManualLayout,
+  mergeTimelineManualLaneTaskOrder,
+  normalizeTimelineManualLayoutByLane,
+  normalizeTimelineManualLayoutState,
+  type GanttRiskFilterMode,
+  type GanttTaskRisk,
+  type TimelineLaneOrderGroupBy,
+  type TimelineManualLayoutByLane,
+  type TimelineManualLayoutState,
+  type TimelineMode,
+  type TimelineScheduleFilter,
+  type TimelineSortMode,
+  type TimelineSwimlane,
+  type TimelineViewState,
+  type TimelineZoom,
+} from '@/components/project-timeline-view-model';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { useTimelineData, type TimelineTask } from '@/hooks/use-timeline-data';
@@ -38,43 +68,6 @@ const DRAG_START_THRESHOLD_PX = 6;
 const LANE_CHANGE_HORIZONTAL_THRESHOLD_PX = 8;
 const UNASSIGNED_LANE_ID = '__unassigned__';
 const UNSCHEDULED_TASK_DND_TYPE = 'application/x-atlaspm-unscheduled-task';
-
-type TimelineZoom = 'day' | 'week' | 'month';
-type TimelineMode = 'timeline' | 'gantt';
-type TimelineSwimlane = 'section' | 'assignee' | 'status';
-type TimelineSortMode = 'manual' | 'startAt' | 'dueAt';
-type TimelineScheduleFilter = 'all' | 'scheduled' | 'unscheduled';
-type GanttRiskFilterMode = 'all' | 'risk';
-type TimelineLaneOrderGroupBy = Extract<TimelineSwimlane, 'section' | 'assignee'>;
-type TimelineManualLaneLayout = {
-  orderedTaskIds: string[];
-  rowByTaskId?: Record<string, number>;
-};
-type TimelineManualLayoutByLane = Record<string, TimelineManualLaneLayout>;
-type TimelineManualLayoutState = Record<TimelineSwimlane, TimelineManualLayoutByLane>;
-type TimelineLaneSubtaskMeta = {
-  visibleTaskIds: string[];
-  childIdsByParentId: Record<string, string[]>;
-  depthByTaskId: Record<string, number>;
-  rowHintByTaskId: Record<string, number>;
-};
-type TimelineViewState = {
-  zoom?: TimelineZoom;
-  anchorDate?: string;
-  swimlane?: TimelineSwimlane;
-  sortMode?: TimelineSortMode;
-  scheduleFilter?: TimelineScheduleFilter;
-  workingDaysOnly?: boolean;
-  ganttRiskFilterMode?: GanttRiskFilterMode;
-  ganttStrictMode?: boolean;
-};
-
-type GanttTaskRisk = {
-  isAtRisk: boolean;
-  overdue: boolean;
-  blockedByOpen: number;
-  blockedByLate: number;
-};
 
 type TimelinePreferences = {
   projectId: string;
@@ -136,14 +129,6 @@ function getLegacyTimelineStorageKey(
   projectId: string,
 ): string {
   return `atlaspm:timeline-view:${userId}:${projectId}:${mode}`;
-}
-
-function createEmptyTimelineManualLayoutState(): TimelineManualLayoutState {
-  return {
-    section: {},
-    assignee: {},
-    status: {},
-  };
 }
 
 const TIMELINE_ZOOM_CONFIG: Record<
@@ -354,30 +339,6 @@ function normalizeTestIdSegment(value: string): string {
   return value.replace(/[^a-zA-Z0-9_-]/g, '-');
 }
 
-function compareTimelineTasks(
-  left: TimelineTask,
-  right: TimelineTask,
-  sortMode: TimelineSortMode,
-): number {
-  if (sortMode === 'startAt') {
-    const leftStart = left.timelineStart ? dayNumber(left.timelineStart) : Number.MAX_SAFE_INTEGER;
-    const rightStart = right.timelineStart
-      ? dayNumber(right.timelineStart)
-      : Number.MAX_SAFE_INTEGER;
-    if (leftStart !== rightStart) return leftStart - rightStart;
-  } else if (sortMode === 'dueAt') {
-    const leftDue = left.timelineEnd ? dayNumber(left.timelineEnd) : Number.MAX_SAFE_INTEGER;
-    const rightDue = right.timelineEnd ? dayNumber(right.timelineEnd) : Number.MAX_SAFE_INTEGER;
-    if (leftDue !== rightDue) return leftDue - rightDue;
-  }
-
-  const sectionDelta = left.section.position - right.section.position;
-  if (sectionDelta !== 0) return sectionDelta;
-  const positionDelta = left.position - right.position;
-  if (positionDelta !== 0) return positionDelta;
-  return left.title.localeCompare(right.title);
-}
-
 function timelineTasksOverlap(left: TimelineTask, right: TimelineTask): boolean {
   if (
     !left.hasSchedule ||
@@ -396,23 +357,6 @@ function timelineTasksOverlap(left: TimelineTask, right: TimelineTask): boolean 
   return !(leftEnd < rightStart || rightEnd < leftStart);
 }
 
-function baselineVarianceDays(task: TimelineTask): number | null {
-  if (!task.baselineEnd || !task.timelineEnd) return null;
-  return dayDiff(task.baselineEnd, task.timelineEnd);
-}
-
-function taskMatchesFilters(
-  task: Task,
-  search: string,
-  statusFilter: 'ALL' | Task['status'],
-  priorityFilter: 'ALL' | NonNullable<Task['priority']>,
-) {
-  const bySearch = !search.trim() || task.title.toLowerCase().includes(search.trim().toLowerCase());
-  const byStatus = statusFilter === 'ALL' || task.status === statusFilter;
-  const byPriority = priorityFilter === 'ALL' || task.priority === priorityFilter;
-  return bySearch && byStatus && byPriority;
-}
-
 function isApiConflictError(error: unknown): boolean {
   if (!(error instanceof Error)) return false;
   return /^API 409:/.test(error.message);
@@ -420,121 +364,6 @@ function isApiConflictError(error: unknown): boolean {
 
 function shiftIsoByDays(value: string | null | undefined, days: number): string | null {
   return shiftUtcDateOnlyIsoByDays(value, days);
-}
-
-function applyTaskScheduleInGroups(
-  groups: SectionTaskGroup[],
-  taskId: string,
-  next: { startAt: string | null; dueAt: string | null },
-) {
-  return groups.map((group) => ({
-    ...group,
-    tasks: group.tasks.map((task) =>
-      task.id === taskId
-        ? {
-            ...task,
-            startAt: next.startAt,
-            dueAt: next.dueAt,
-          }
-        : task,
-    ),
-  }));
-}
-
-function applyTaskSchedulesInGroups(
-  groups: SectionTaskGroup[],
-  nextByTaskId: Map<string, { startAt: string | null; dueAt: string | null }>,
-) {
-  return groups.map((group) => ({
-    ...group,
-    tasks: group.tasks.map((task) => {
-      const next = nextByTaskId.get(task.id);
-      return next
-        ? {
-            ...task,
-            startAt: next.startAt,
-            dueAt: next.dueAt,
-          }
-        : task;
-    }),
-  }));
-}
-
-function findTaskInGroups(groups: SectionTaskGroup[], taskId: string): Task | undefined {
-  for (const group of groups) {
-    const task = group.tasks.find((candidate) => candidate.id === taskId);
-    if (task) return task;
-  }
-  return undefined;
-}
-
-function applyResolvedTaskInGroups(groups: SectionTaskGroup[], resolvedTask: Task) {
-  const withoutTask = groups.map((group) => ({
-    ...group,
-    tasks: group.tasks.filter((task) => task.id !== resolvedTask.id),
-  }));
-
-  return withoutTask.map((group) =>
-    group.section.id === resolvedTask.sectionId
-      ? { ...group, tasks: [...group.tasks, resolvedTask] }
-      : group,
-  );
-}
-
-function applyResolvedTasksInGroups(groups: SectionTaskGroup[], resolvedTasks: Task[]) {
-  return resolvedTasks.reduce(
-    (current, resolvedTask) => applyResolvedTaskInGroups(current, resolvedTask),
-    groups,
-  );
-}
-
-function applyTaskTimelineMoveInGroups(
-  groups: SectionTaskGroup[],
-  taskId: string,
-  next: {
-    startAt?: string | null;
-    dueAt?: string | null;
-    assigneeUserId?: string | null;
-    sectionId?: string;
-    status?: Task['status'];
-  },
-) {
-  let movedTask: Task | null = null;
-  const withoutTask = groups.map((group) => ({
-    ...group,
-    tasks: group.tasks.filter((task) => {
-      if (task.id !== taskId) return true;
-      const updatedTask: Task = { ...task };
-      if (next.startAt !== undefined) {
-        updatedTask.startAt = next.startAt;
-      }
-      if (next.dueAt !== undefined) {
-        updatedTask.dueAt = next.dueAt;
-      }
-      if (next.assigneeUserId !== undefined) {
-        updatedTask.assigneeUserId = next.assigneeUserId;
-      }
-      if (next.sectionId !== undefined) {
-        updatedTask.sectionId = next.sectionId;
-      }
-      if (next.status !== undefined) {
-        updatedTask.status = next.status;
-        updatedTask.completedAt =
-          next.status === 'DONE' ? (task.completedAt ?? new Date().toISOString()) : null;
-      }
-      movedTask = updatedTask;
-      return false;
-    }),
-  }));
-
-  if (!movedTask) return groups;
-  const finalizedTask: Task = movedTask;
-  const targetSectionId = next.sectionId ?? finalizedTask.sectionId;
-  return withoutTask.map((group) =>
-    group.section.id === targetSectionId
-      ? { ...group, tasks: [...group.tasks, finalizedTask] }
-      : group,
-  );
 }
 
 function parseAssigneeLaneId(laneId: string): string | null | undefined {
@@ -790,14 +619,6 @@ function parseSavedProjectViewState(
   return Object.keys(normalizedLegacy).length > 0 ? normalizedLegacy : null;
 }
 
-function areSavedProjectViewStatesEqual(
-  mode: TimelineMode,
-  left: SavedProjectViewState | null | undefined,
-  right: SavedProjectViewState,
-): boolean {
-  return JSON.stringify(normalizeProjectViewState(mode, left)) === JSON.stringify(normalizeProjectViewState(mode, right));
-}
-
 function getTimelineLaneOrderStorageKey(
   projectId: string,
   groupBy: TimelineLaneOrderGroupBy,
@@ -816,156 +637,6 @@ function getTimelineManualLayoutStorageKey(
   return userId
     ? `${TIMELINE_MANUAL_LAYOUT_STORAGE_PREFIX}:${projectId}:${groupBy}:${userId}`
     : `${TIMELINE_MANUAL_LAYOUT_STORAGE_PREFIX}:${projectId}:${groupBy}`;
-}
-
-function normalizeTimelineManualLayoutByLane(value: unknown): TimelineManualLayoutByLane {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) return {};
-  const next: TimelineManualLayoutByLane = {};
-  for (const [laneIdRaw, rawTaskIds] of Object.entries(value as Record<string, unknown>)) {
-    const laneId = laneIdRaw.trim();
-    if (!laneId) continue;
-    const candidate =
-      Array.isArray(rawTaskIds)
-        ? { orderedTaskIds: rawTaskIds, rowByTaskId: {} as Record<string, unknown> }
-        : rawTaskIds && typeof rawTaskIds === 'object' && !Array.isArray(rawTaskIds)
-          ? {
-              orderedTaskIds: Array.isArray((rawTaskIds as Record<string, unknown>).orderedTaskIds)
-                ? ((rawTaskIds as Record<string, unknown>).orderedTaskIds as unknown[])
-                : Array.isArray((rawTaskIds as Record<string, unknown>).taskIds)
-                  ? ((rawTaskIds as Record<string, unknown>).taskIds as unknown[])
-                  : [],
-              rowByTaskId:
-                (rawTaskIds as Record<string, unknown>).rowByTaskId &&
-                typeof (rawTaskIds as Record<string, unknown>).rowByTaskId === 'object' &&
-                !Array.isArray((rawTaskIds as Record<string, unknown>).rowByTaskId)
-                  ? ((rawTaskIds as Record<string, unknown>).rowByTaskId as Record<string, unknown>)
-                  : (rawTaskIds as Record<string, unknown>).rowHints &&
-                      typeof (rawTaskIds as Record<string, unknown>).rowHints === 'object' &&
-                      !Array.isArray((rawTaskIds as Record<string, unknown>).rowHints)
-                    ? ((rawTaskIds as Record<string, unknown>).rowHints as Record<string, unknown>)
-                    : {},
-            }
-          : null;
-    if (!candidate) continue;
-    const seenTaskIds = new Set<string>();
-    const normalizedTaskIds: string[] = [];
-    for (const taskId of candidate.orderedTaskIds) {
-      if (typeof taskId !== 'string') continue;
-      const trimmedTaskId = taskId.trim();
-      if (!trimmedTaskId || seenTaskIds.has(trimmedTaskId)) continue;
-      seenTaskIds.add(trimmedTaskId);
-      normalizedTaskIds.push(trimmedTaskId);
-    }
-    if (normalizedTaskIds.length > 0) {
-      const rowByTaskId: Record<string, number> = {};
-      const maxRowIndex = Math.max(normalizedTaskIds.length - 1, 0);
-      for (const [taskIdRaw, rowIndex] of Object.entries(candidate.rowByTaskId)) {
-        const taskId = taskIdRaw.trim();
-        if (!taskId || !normalizedTaskIds.includes(taskId)) continue;
-        const numericRowIndex = Number(rowIndex);
-        if (!Number.isInteger(numericRowIndex) || numericRowIndex < 0) continue;
-        rowByTaskId[taskId] = Math.min(numericRowIndex, maxRowIndex);
-      }
-      next[laneId] =
-        Object.keys(rowByTaskId).length > 0
-          ? { orderedTaskIds: normalizedTaskIds, rowByTaskId }
-          : { orderedTaskIds: normalizedTaskIds };
-    }
-  }
-  return next;
-}
-
-function normalizeTimelineManualLayoutState(value: unknown): TimelineManualLayoutState {
-  const next = createEmptyTimelineManualLayoutState();
-  if (!value || typeof value !== 'object' || Array.isArray(value)) return next;
-  const candidate = value as Record<string, unknown>;
-  next.section = normalizeTimelineManualLayoutByLane(candidate.section);
-  next.assignee = normalizeTimelineManualLayoutByLane(candidate.assignee);
-  next.status = normalizeTimelineManualLayoutByLane(candidate.status);
-  return next;
-}
-
-function hasTimelineManualLayout(layout: TimelineManualLayoutByLane): boolean {
-  return Object.values(layout).some((laneTaskOrder) => laneTaskOrder.orderedTaskIds.length > 0);
-}
-
-function mergeTimelineManualLaneTaskOrder(
-  existingLaneLayout: TimelineManualLaneLayout | undefined,
-  nextTaskOrder: string[],
-  nextRowByTaskId?: Record<string, number>,
-): TimelineManualLaneLayout {
-  const seenTaskIds = new Set(nextTaskOrder);
-  const orderedTaskIds = [
-    ...nextTaskOrder,
-    ...(existingLaneLayout?.orderedTaskIds ?? []).filter((taskId) => !seenTaskIds.has(taskId)),
-  ];
-  const rowByTaskId = {
-    ...(existingLaneLayout?.rowByTaskId ?? {}),
-    ...(nextRowByTaskId ?? {}),
-  };
-  for (const taskId of Object.keys(rowByTaskId)) {
-    if (!orderedTaskIds.includes(taskId)) delete rowByTaskId[taskId];
-  }
-  return Object.keys(rowByTaskId).length > 0 ? { orderedTaskIds, rowByTaskId } : { orderedTaskIds };
-}
-
-function getTimelineManualOrderedTaskIdsByLane(layout: TimelineManualLayoutByLane): Record<string, string[]> {
-  return Object.fromEntries(
-    Object.entries(layout)
-      .filter(([, laneLayout]) => laneLayout.orderedTaskIds.length > 0)
-      .map(([laneId, laneLayout]) => [laneId, laneLayout.orderedTaskIds]),
-  );
-}
-
-function getTimelineManualRowByTaskIdByLane(
-  layout: TimelineManualLayoutByLane,
-): Record<string, Record<string, number>> {
-  return Object.fromEntries(
-    Object.entries(layout)
-      .filter(([, laneLayout]) => Boolean(laneLayout.rowByTaskId && Object.keys(laneLayout.rowByTaskId).length))
-      .map(([laneId, laneLayout]) => [laneId, laneLayout.rowByTaskId ?? {}]),
-  );
-}
-
-function buildTimelineLaneSubtaskMeta<TTask extends { id: string; parentId?: string | null }>(
-  tasks: TTask[],
-  collapsedParentIds: Set<string>,
-  baseRowByTaskId?: Record<string, number>,
-): TimelineLaneSubtaskMeta {
-  const taskById = new Map(tasks.map((task) => [task.id, task] as const));
-  const laneTaskIds = new Set(tasks.map((task) => task.id));
-  const childIdsByParentId: Record<string, string[]> = {};
-  for (const task of tasks) {
-    const parentId = task.parentId ?? null;
-    if (!parentId || !laneTaskIds.has(parentId)) continue;
-    (childIdsByParentId[parentId] ??= []).push(task.id);
-  }
-
-  const roots = tasks.filter((task) => !task.parentId || !laneTaskIds.has(task.parentId));
-  const visibleTaskIds: string[] = [];
-  const depthByTaskId: Record<string, number> = {};
-  const rowHintByTaskId: Record<string, number> = {};
-
-  const visit = (taskId: string, depth: number, inheritedRowHint: number) => {
-    const task = taskById.get(taskId);
-    if (!task) return;
-    depthByTaskId[taskId] = depth;
-    const ownRowHint = Math.max(baseRowByTaskId?.[taskId] ?? 0, inheritedRowHint);
-    rowHintByTaskId[taskId] = ownRowHint;
-    visibleTaskIds.push(taskId);
-    if (collapsedParentIds.has(taskId)) return;
-    const childIds = childIdsByParentId[taskId] ?? [];
-    childIds.forEach((childId) => visit(childId, depth + 1, ownRowHint + 1));
-  };
-
-  roots.forEach((task) => visit(task.id, 0, baseRowByTaskId?.[task.id] ?? 0));
-
-  return {
-    visibleTaskIds,
-    childIdsByParentId,
-    depthByTaskId,
-    rowHintByTaskId,
-  };
 }
 
 function readStoredTimelineLaneOrder(keys: Array<string | null | undefined>): string[] {
@@ -1512,71 +1183,44 @@ export function ProjectScheduleCanvas({
     return list;
   }, [timeline.window.end, timeline.window.start]);
 
-  const baseFilteredTasks = useMemo(() => {
-    return timeline.tasks
-      .filter((task) => taskMatchesFilters(task, search, statusFilter, priorityFilter))
-      .filter((task) => {
-        if (effectiveScheduleFilter === 'scheduled') return task.hasSchedule;
-        if (effectiveScheduleFilter === 'unscheduled') return !task.hasSchedule;
-        return true;
-      })
-      .sort((left, right) => compareTimelineTasks(left, right, effectiveSortMode));
-  }, [
-    effectiveScheduleFilter,
-    effectiveSortMode,
-    priorityFilter,
-    search,
-    statusFilter,
-    timeline.tasks,
-  ]);
-
-  const ganttRiskByTaskId = useMemo(() => {
-    const taskById = new Map(baseFilteredTasks.map((task) => [task.id, task]));
-    const incomingDependenciesByTarget = new Map<string, TimelineTask[]>();
-    for (const edge of timeline.dependencyEdges) {
-      if (edge.type === 'RELATES_TO') continue;
-      const sourceTask = taskById.get(edge.source);
-      const targetTask = taskById.get(edge.target);
-      if (!sourceTask || !targetTask) continue;
-      const list = incomingDependenciesByTarget.get(edge.target) ?? [];
-      list.push(sourceTask);
-      incomingDependenciesByTarget.set(edge.target, list);
-    }
-
-    const today = startOfDay(new Date());
-    const todayDay = dayNumber(today);
-    const next = new Map<string, GanttTaskRisk>();
-    for (const task of baseFilteredTasks) {
-      const blockers = incomingDependenciesByTarget.get(task.id) ?? [];
-      let blockedByOpen = 0;
-      let blockedByLate = 0;
-      const taskDueDay = task.timelineEnd ? dayNumber(task.timelineEnd) : null;
-      for (const blocker of blockers) {
-        if (blocker.status !== 'DONE') {
-          blockedByOpen += 1;
-        }
-        if (
-          taskDueDay !== null &&
-          blocker.timelineEnd &&
-          dayNumber(blocker.timelineEnd) > taskDueDay
-        ) {
-          blockedByLate += 1;
-        }
-      }
-
-      const overdue = Boolean(
-        task.timelineEnd && dayNumber(task.timelineEnd) < todayDay && task.status !== 'DONE',
-      );
-      const isAtRisk = overdue || blockedByOpen > 0 || blockedByLate > 0;
-      next.set(task.id, {
-        isAtRisk,
-        overdue,
-        blockedByOpen,
-        blockedByLate,
-      });
-    }
-    return next;
-  }, [baseFilteredTasks, timeline.dependencyEdges]);
+  const timelineTaskViewModel = useMemo(
+    () =>
+      buildTimelineTaskViewModel({
+        tasks: timeline.tasks,
+        dependencyEdges: timeline.dependencyEdges,
+        mode,
+        search,
+        statusFilter,
+        priorityFilter,
+        effectiveScheduleFilter,
+        effectiveSortMode,
+        ganttRiskFilterMode,
+        today: new Date(),
+      }),
+    [
+      effectiveScheduleFilter,
+      effectiveSortMode,
+      ganttRiskFilterMode,
+      mode,
+      priorityFilter,
+      search,
+      statusFilter,
+      timeline.dependencyEdges,
+      timeline.tasks,
+    ],
+  );
+  const {
+    filteredTasks,
+    filteredTaskIds,
+    ganttAheadTasks,
+    ganttBlockedTasks,
+    ganttDelayedTasks,
+    ganttRiskByTaskId,
+    ganttRiskTasks,
+    ganttVarianceByTaskId,
+    scheduledTimelineTasks,
+    totalDependencyEdges,
+  } = timelineTaskViewModel;
 
   const describeTaskRisk = (risk: GanttTaskRisk | undefined) => {
     if (!risk?.isAtRisk) return null;
@@ -1584,15 +1228,6 @@ export function ProjectScheduleCanvas({
     if (risk.blockedByOpen > 0) return t('ganttRiskBlocked');
     return t('ganttRiskLateDependency');
   };
-
-  const filteredTasks = useMemo(() => {
-    if (mode !== 'gantt' || ganttRiskFilterMode === 'all') return baseFilteredTasks;
-    return baseFilteredTasks.filter((task) => ganttRiskByTaskId.get(task.id)?.isAtRisk);
-  }, [baseFilteredTasks, ganttRiskByTaskId, ganttRiskFilterMode, mode]);
-  const scheduledTimelineTasks = useMemo(
-    () => filteredTasks.filter((task) => task.hasSchedule),
-    [filteredTasks],
-  );
   const preferredLaneOrder = useMemo(() => {
     const storedLaneOrder = readStoredTimelineLaneOrder([
       laneOrderStorageUserKey,
@@ -1744,10 +1379,6 @@ export function ProjectScheduleCanvas({
     });
   }, [timelineLanes]);
 
-  const filteredTaskIds = useMemo(
-    () => new Set(filteredTasks.map((task) => task.id)),
-    [filteredTasks],
-  );
   const taskHasSubtasksById = useMemo(() => {
     const next = new Map<string, boolean>();
     for (const task of timeline.tasks) {
@@ -1764,40 +1395,7 @@ export function ProjectScheduleCanvas({
 
   const scheduledTasks = filteredTasks.filter((task) => task.hasSchedule && task.inWindow);
   const unscheduledTasks = filteredTasks.filter((task) => !task.hasSchedule);
-  const ganttRiskTasks = useMemo(
-    () => baseFilteredTasks.filter((task) => ganttRiskByTaskId.get(task.id)?.isAtRisk),
-    [baseFilteredTasks, ganttRiskByTaskId],
-  );
-  const ganttBlockedTasks = useMemo(
-    () =>
-      baseFilteredTasks.filter((task) => (ganttRiskByTaskId.get(task.id)?.blockedByOpen ?? 0) > 0),
-    [baseFilteredTasks, ganttRiskByTaskId],
-  );
-  const ganttVarianceByTaskId = useMemo(() => {
-    const next = new Map<string, number>();
-    for (const task of baseFilteredTasks) {
-      const variance = baselineVarianceDays(task);
-      if (variance !== null) next.set(task.id, variance);
-    }
-    return next;
-  }, [baseFilteredTasks]);
-  const ganttDelayedTasks = useMemo(
-    () => baseFilteredTasks.filter((task) => (ganttVarianceByTaskId.get(task.id) ?? 0) > 0),
-    [baseFilteredTasks, ganttVarianceByTaskId],
-  );
-  const ganttAheadTasks = useMemo(
-    () => baseFilteredTasks.filter((task) => (ganttVarianceByTaskId.get(task.id) ?? 0) < 0),
-    [baseFilteredTasks, ganttVarianceByTaskId],
-  );
   const gridWidth = Math.max(1, days.length) * zoomConfig.dayColWidth;
-
-  const totalDependencyEdges = useMemo(
-    () =>
-      timeline.dependencyEdges.filter(
-        (edge) => filteredTaskIds.has(edge.source) && filteredTaskIds.has(edge.target),
-      ).length,
-    [filteredTaskIds, timeline.dependencyEdges],
-  );
 
   const saveLaneOrderMutation = useMutation({
     mutationFn: async ({
@@ -2457,7 +2055,7 @@ export function ProjectScheduleCanvas({
   }
 
   const timelineLayout = useMemo(() => {
-    return buildTimelineLayout({
+    return buildTimelineLayout<TimelineTask>({
       lanes: visibleTimelineLanes,
       windowStart: timeline.window.start,
       windowEnd: timeline.window.end,

--- a/apps/web-ui/src/components/project-timeline-view.tsx
+++ b/apps/web-ui/src/components/project-timeline-view.tsx
@@ -1195,7 +1195,7 @@ export function ProjectScheduleCanvas({
         effectiveScheduleFilter,
         effectiveSortMode,
         ganttRiskFilterMode,
-        today: new Date(),
+        today,
       }),
     [
       effectiveScheduleFilter,
@@ -1205,6 +1205,7 @@ export function ProjectScheduleCanvas({
       priorityFilter,
       search,
       statusFilter,
+      today,
       timeline.dependencyEdges,
       timeline.tasks,
     ],

--- a/apps/web-ui/vitest.config.ts
+++ b/apps/web-ui/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url)),
+      '@atlaspm/domain': fileURLToPath(new URL('../../packages/domain/src/index.ts', import.meta.url)),
     },
   },
   test: {

--- a/packages/domain/src/__tests__/timeline-layout.test.ts
+++ b/packages/domain/src/__tests__/timeline-layout.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
+  buildTimelineLaneSubtaskMeta,
   buildTimelineLanes,
   buildTimelineLayout,
   buildTimelineTaskOrderByLane,
@@ -646,6 +647,39 @@ test('buildTimelineLayout preserves manual vertical order while still compacting
   assert.deepEqual(layout.taskRowsById['task-late'], { top: 32, height: 40 });
   assert.deepEqual(layout.taskRowsById['task-early'], { top: 32, height: 40 });
   assert.deepEqual(layout.taskRowsById['task-overlap'], { top: 72, height: 40 });
+});
+
+test('buildTimelineLaneSubtaskMeta hides collapsed descendants and cascades row hints', () => {
+  const meta = buildTimelineLaneSubtaskMeta(
+    [
+      { id: 'parent', parentId: null },
+      { id: 'child', parentId: 'parent' },
+      { id: 'grandchild', parentId: 'child' },
+      { id: 'sibling', parentId: null },
+    ],
+    new Set(['child']),
+    {
+      parent: 1,
+      grandchild: 0,
+      sibling: 4,
+    },
+  );
+
+  assert.deepEqual(meta.visibleTaskIds, ['parent', 'child', 'sibling']);
+  assert.deepEqual(meta.childIdsByParentId, {
+    parent: ['child'],
+    child: ['grandchild'],
+  });
+  assert.deepEqual(meta.depthByTaskId, {
+    parent: 0,
+    child: 1,
+    sibling: 0,
+  });
+  assert.deepEqual(meta.rowHintByTaskId, {
+    parent: 1,
+    child: 2,
+    sibling: 4,
+  });
 });
 
 test('buildTimelineLayout respects manual order for overlapping tasks even when dates start earlier', () => {

--- a/packages/domain/src/__tests__/timeline-layout.test.ts
+++ b/packages/domain/src/__tests__/timeline-layout.test.ts
@@ -714,6 +714,32 @@ test('buildTimelineLaneSubtaskMeta keeps cyclic tasks visible', () => {
   });
 });
 
+test('buildTimelineLaneSubtaskMeta keeps collapsed cyclic parents visible for re-expansion', () => {
+  const meta = buildTimelineLaneSubtaskMeta(
+    [
+      { id: 'cycle-a', parentId: 'cycle-b' },
+      { id: 'cycle-b', parentId: 'cycle-a' },
+    ],
+    new Set(['cycle-a']),
+    {
+      'cycle-a': 3,
+      'cycle-b': 1,
+    },
+  );
+
+  assert.deepEqual(meta.visibleTaskIds, ['cycle-a']);
+  assert.deepEqual(meta.childIdsByParentId, {
+    'cycle-a': ['cycle-b'],
+    'cycle-b': ['cycle-a'],
+  });
+  assert.deepEqual(meta.depthByTaskId, {
+    'cycle-a': 0,
+  });
+  assert.deepEqual(meta.rowHintByTaskId, {
+    'cycle-a': 3,
+  });
+});
+
 test('buildTimelineLayout respects manual order for overlapping tasks even when dates start earlier', () => {
   const layout = buildTimelineLayout({
     lanes: [

--- a/packages/domain/src/__tests__/timeline-layout.test.ts
+++ b/packages/domain/src/__tests__/timeline-layout.test.ts
@@ -682,6 +682,38 @@ test('buildTimelineLaneSubtaskMeta hides collapsed descendants and cascades row 
   });
 });
 
+test('buildTimelineLaneSubtaskMeta keeps cyclic tasks visible', () => {
+  const meta = buildTimelineLaneSubtaskMeta(
+    [
+      { id: 'cycle-a', parentId: 'cycle-b' },
+      { id: 'cycle-b', parentId: 'cycle-a' },
+      { id: 'self-parent', parentId: 'self-parent' },
+    ],
+    new Set(),
+    {
+      'cycle-b': 2,
+      'self-parent': 4,
+    },
+  );
+
+  assert.deepEqual(meta.visibleTaskIds, ['cycle-a', 'cycle-b', 'self-parent']);
+  assert.deepEqual(meta.childIdsByParentId, {
+    'cycle-a': ['cycle-b'],
+    'cycle-b': ['cycle-a'],
+    'self-parent': ['self-parent'],
+  });
+  assert.deepEqual(meta.depthByTaskId, {
+    'cycle-a': 0,
+    'cycle-b': 1,
+    'self-parent': 0,
+  });
+  assert.deepEqual(meta.rowHintByTaskId, {
+    'cycle-a': 0,
+    'cycle-b': 2,
+    'self-parent': 4,
+  });
+});
+
 test('buildTimelineLayout respects manual order for overlapping tasks even when dates start earlier', () => {
   const layout = buildTimelineLayout({
     lanes: [

--- a/packages/domain/src/services/timeline-layout.ts
+++ b/packages/domain/src/services/timeline-layout.ts
@@ -82,6 +82,13 @@ export type TimelineLayout<TTask extends TimelineLayoutTaskInput = TimelineLayou
   totalRowCount: number;
 };
 
+export type TimelineLaneSubtaskMeta = {
+  visibleTaskIds: string[];
+  childIdsByParentId: Record<string, string[]>;
+  depthByTaskId: Record<string, number>;
+  rowHintByTaskId: Record<string, number>;
+};
+
 export type TimelineManualLanePlacement = {
   orderedTaskIds?: string[];
   rowByTaskId?: Record<string, number>;
@@ -550,4 +557,45 @@ export function buildTimelineTaskOrderByLane<TTask extends TimelineLayoutTaskInp
       .map((task) => task.id);
   }
   return laneTaskOrder;
+}
+
+export function buildTimelineLaneSubtaskMeta<TTask extends { id: string; parentId?: string | null }>(
+  tasks: TTask[],
+  collapsedParentIds: Set<string>,
+  baseRowByTaskId?: Record<string, number>,
+): TimelineLaneSubtaskMeta {
+  const taskById = new Map(tasks.map((task) => [task.id, task] as const));
+  const laneTaskIds = new Set(tasks.map((task) => task.id));
+  const childIdsByParentId: Record<string, string[]> = {};
+  for (const task of tasks) {
+    const parentId = task.parentId ?? null;
+    if (!parentId || !laneTaskIds.has(parentId)) continue;
+    (childIdsByParentId[parentId] ??= []).push(task.id);
+  }
+
+  const roots = tasks.filter((task) => !task.parentId || !laneTaskIds.has(task.parentId));
+  const visibleTaskIds: string[] = [];
+  const depthByTaskId: Record<string, number> = {};
+  const rowHintByTaskId: Record<string, number> = {};
+
+  const visit = (taskId: string, depth: number, inheritedRowHint: number) => {
+    const task = taskById.get(taskId);
+    if (!task) return;
+    depthByTaskId[taskId] = depth;
+    const ownRowHint = Math.max(baseRowByTaskId?.[taskId] ?? 0, inheritedRowHint);
+    rowHintByTaskId[taskId] = ownRowHint;
+    visibleTaskIds.push(taskId);
+    if (collapsedParentIds.has(taskId)) return;
+    const childIds = childIdsByParentId[taskId] ?? [];
+    childIds.forEach((childId) => visit(childId, depth + 1, ownRowHint + 1));
+  };
+
+  roots.forEach((task) => visit(task.id, 0, baseRowByTaskId?.[task.id] ?? 0));
+
+  return {
+    visibleTaskIds,
+    childIdsByParentId,
+    depthByTaskId,
+    rowHintByTaskId,
+  };
 }

--- a/packages/domain/src/services/timeline-layout.ts
+++ b/packages/domain/src/services/timeline-layout.ts
@@ -593,8 +593,29 @@ export function buildTimelineLaneSubtaskMeta<TTask extends { id: string; parentI
     childIds.forEach((childId) => visit(childId, depth + 1, ownRowHint + 1));
   };
 
+  const shouldFallbackVisit = (taskId: string) => {
+    const seenTaskIds = new Set<string>([taskId]);
+    let currentTask = taskById.get(taskId);
+    while (currentTask) {
+      const parentId = currentTask.parentId ?? null;
+      if (!parentId || !laneTaskIds.has(parentId)) {
+        return false;
+      }
+      if (collapsedParentIds.has(parentId)) {
+        return false;
+      }
+      if (seenTaskIds.has(parentId)) {
+        return true;
+      }
+      seenTaskIds.add(parentId);
+      currentTask = taskById.get(parentId);
+    }
+    return false;
+  };
+
   roots.forEach((task) => visit(task.id, 0, baseRowByTaskId?.[task.id] ?? 0));
   for (const task of tasks) {
+    if (!shouldFallbackVisit(task.id)) continue;
     visit(task.id, 0, baseRowByTaskId?.[task.id] ?? 0);
   }
 

--- a/packages/domain/src/services/timeline-layout.ts
+++ b/packages/domain/src/services/timeline-layout.ts
@@ -601,11 +601,11 @@ export function buildTimelineLaneSubtaskMeta<TTask extends { id: string; parentI
       if (!parentId || !laneTaskIds.has(parentId)) {
         return false;
       }
-      if (collapsedParentIds.has(parentId)) {
-        return false;
-      }
       if (seenTaskIds.has(parentId)) {
         return true;
+      }
+      if (collapsedParentIds.has(parentId)) {
+        return false;
       }
       seenTaskIds.add(parentId);
       currentTask = taskById.get(parentId);

--- a/packages/domain/src/services/timeline-layout.ts
+++ b/packages/domain/src/services/timeline-layout.ts
@@ -577,10 +577,13 @@ export function buildTimelineLaneSubtaskMeta<TTask extends { id: string; parentI
   const visibleTaskIds: string[] = [];
   const depthByTaskId: Record<string, number> = {};
   const rowHintByTaskId: Record<string, number> = {};
+  const visitedTaskIds = new Set<string>();
 
   const visit = (taskId: string, depth: number, inheritedRowHint: number) => {
+    if (visitedTaskIds.has(taskId)) return;
     const task = taskById.get(taskId);
     if (!task) return;
+    visitedTaskIds.add(taskId);
     depthByTaskId[taskId] = depth;
     const ownRowHint = Math.max(baseRowByTaskId?.[taskId] ?? 0, inheritedRowHint);
     rowHintByTaskId[taskId] = ownRowHint;
@@ -591,6 +594,9 @@ export function buildTimelineLaneSubtaskMeta<TTask extends { id: string; parentI
   };
 
   roots.forEach((task) => visit(task.id, 0, baseRowByTaskId?.[task.id] ?? 0));
+  for (const task of tasks) {
+    visit(task.id, 0, baseRowByTaskId?.[task.id] ?? 0);
+  }
 
   return {
     visibleTaskIds,


### PR DESCRIPTION
## What changed
- extracted pure timeline task filtering, gantt risk derivation, and manual-layout normalization into `apps/web-ui/src/components/project-timeline-view-model.ts`
- moved lane subtask row-hint and collapsed-tree layout logic into `packages/domain/src/services/timeline-layout.ts`
- updated `project-timeline-view.tsx` to delegate to the extracted helpers instead of shaping that state inline
- added focused unit coverage for the new web-ui helper and the domain lane-subtask layout rule
- taught `apps/web-ui` vitest to resolve the workspace `@atlaspm/domain` package during tests

## Why
`project-timeline-view.tsx` had accumulated a large amount of pure state-derivation and layout-shaping logic. This checkpoint pulls those boundaries outward first so later extraction can keep the rendering component focused on interaction wiring and presentation without changing behavior.

## Impact
- no intended timeline, gantt, or manual-layout behavior change
- narrower tests now pin the extracted boundaries directly
- `project-timeline-view.tsx` is materially smaller and easier to continue splitting

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm --filter @atlaspm/domain test`
- `pnpm --filter @atlaspm/web-ui lint`
- `pnpm --filter @atlaspm/web-ui type-check`
- `pnpm --filter @atlaspm/web-ui test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a timeline/Gantt view-model, persisted view-state and manual lane layout normalization, per-task risk/variance metrics, and lane subtask metadata/utilities.
* **Tests**
  * Added comprehensive tests for view-model behavior (filtering, sorting, scheduling, risk), layout normalization, and lane subtask handling including cyclic/edge cases.
* **Refactor**
  * Moved timeline/Gantt data-shaping utilities into a dedicated module and updated the component to consume precomputed view-model outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->